### PR TITLE
feat(v3.0.0): Decouple task assignment into resources and add admin panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,67 @@ y este proyecto adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-07-08
+
+Epic recursos asignables + panel admin: nueva entidad `resources` (kind
+`user`|`placeholder`) desacopla la asignación de tareas y workload de `users`,
+permitiendo asignar trabajo a personas sin cuenta (placeholders) y vincularlas
+después a un usuario real. Incluye un panel de administración para gestionar
+usuarios y recursos. A diferencia del bump Major anterior (v2.0.0), este PR **sí
+introduce breaking changes** de contrato REST: ver sección Changed.
+
+### Added
+- Módulo `resources` (`/v1/resources`): CRUD admin-only, lectura abierta a
+  cualquier autenticado (la necesita el selector de responsable del Gantt),
+  `PATCH /v1/resources/:id/link-user` para vincular un placeholder a un usuario
+  real (reasigna sus tasks/workload y borra el resource huérfano en una
+  transacción), y `remove` restringido a placeholders sin tasks ni workload
+  asociados
+- `POST /v1/users` (admin): crea usuario en Firebase y en DB (con su `resource`
+  `kind='user'`) en una transacción; compensa borrando el usuario de Firebase si
+  la transacción DB falla
+- `PATCH /v1/users/:id` (admin): edita `role`/`status`, con invariante que impide
+  dejar el sistema sin ningún admin activo
+- `PATCH /v1/projects/:projectId/members/:userId` (manager de proyecto): edita el
+  rol de un miembro
+- `UserStatus` (`active`/`disabled`): los usuarios `disabled` quedan bloqueados en
+  los tres paths de resolución de identidad del `AuthGuard`
+- Panel de administración `/admin/users` y `/admin/resources`, protegido por
+  `AdminRoute` (rol global `admin`)
+- Columna de avatar de responsable en el Gantt, inyectada por DOM
+  (`ganttAssigneeCells.ts`) sobre las celdas `.wx-cell[data-col-id="assignee"]`
+- 4 migraciones Prisma: `add_resources_and_user_status`,
+  `backfill_resources_from_users`, `repoint_task_assignee_to_resources`,
+  `repoint_workload_to_resources`
+- Tests: 12 unitarios (`resources.service.spec.ts`) y 11 e2e
+  (`resources.e2e-spec.ts`)
+
+### Changed
+- **BREAKING**: `tasks.assigneeId` y `workload` ahora referencian `resources.id`
+  en lugar de `users.id` (remapeado con backfill en las 4 migraciones nuevas)
+- **BREAKING**: `WorkloadResponse`, `CreateWorkloadDto` y `WorkloadQueryDto`
+  renombran el campo `userId` a `resourceId`
+- MCP: la tool `assign_task` busca contra `resources` (`searchResources`) en
+  lugar de `users`; la búsqueda filtra `status=active` server-side
+- `resolveAssigneeId` (tasks) renombrado a `resolveResourceId`; exige que el
+  resource exista y esté `status='active'`
+- `MemberService`/`useMembers`: roles y permisos de proyecto calculados a partir
+  de datos reales (`projectRole`, `computePermissions`) en lugar de valores
+  hardcodeados
+- `ProjectMember.role` (frontend, `domain.ts`) tipado como `ProjectRole` en lugar
+  de `UserRole`
+
+### Fixed
+- El template de assignee del Gantt se renderizaba como texto escapado (wx-react-gantt
+  no interpreta HTML devuelto por `template`); reemplazado por inyección DOM
+- Roles y permisos de miembros de proyecto mostraban etiquetas incorrectas al
+  reutilizar las constantes de rol global (`admin`/`pm`/`member`) para el rol de
+  proyecto (`manager`/`contributor`/`viewer`)
+
+### Security
+- Usuarios con `status='disabled'` no pueden autenticarse por ninguno de los tres
+  paths del `AuthGuard` (Firebase ID token, JWT OAuth interno, API key)
+
 ## [2.1.0] - 2026-07-03
 
 ### Added

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -76,6 +76,44 @@
         ]
       }
     },
+    "/users/{id}": {
+      "patch": {
+        "operationId": "UsersController_adminUpdate",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateUserAdminDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "users"
+        ]
+      }
+    },
     "/projects": {
       "post": {
         "operationId": "ProjectsController_create",
@@ -1098,6 +1136,50 @@
       }
     },
     "/projects/{projectId}/members/{userId}": {
+      "patch": {
+        "operationId": "ProjectMembersController_updateRole",
+        "parameters": [
+          {
+            "name": "projectId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "userId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProjectMemberDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "project-members"
+        ]
+      },
       "delete": {
         "operationId": "ProjectMembersController_remove",
         "parameters": [
@@ -1130,6 +1212,180 @@
         ],
         "tags": [
           "project-members"
+        ]
+      }
+    },
+    "/resources": {
+      "get": {
+        "operationId": "ResourcesController_list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "resources"
+        ]
+      },
+      "post": {
+        "operationId": "ResourcesController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateResourceDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "resources"
+        ]
+      }
+    },
+    "/resources/{id}": {
+      "get": {
+        "operationId": "ResourcesController_getById",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "resources"
+        ]
+      },
+      "patch": {
+        "operationId": "ResourcesController_update",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateResourceDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "resources"
+        ]
+      },
+      "delete": {
+        "operationId": "ResourcesController_remove",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "resources"
+        ]
+      }
+    },
+    "/resources/{id}/link-user": {
+      "patch": {
+        "operationId": "ResourcesController_linkUser",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LinkResourceUserDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "resources"
         ]
       }
     },
@@ -1541,6 +1797,10 @@
       }
     },
     "schemas": {
+      "UpdateUserAdminDto": {
+        "type": "object",
+        "properties": {}
+      },
       "CreateProjectDto": {
         "type": "object",
         "properties": {}
@@ -1594,6 +1854,22 @@
         "properties": {}
       },
       "AddProjectMemberDto": {
+        "type": "object",
+        "properties": {}
+      },
+      "UpdateProjectMemberDto": {
+        "type": "object",
+        "properties": {}
+      },
+      "CreateResourceDto": {
+        "type": "object",
+        "properties": {}
+      },
+      "UpdateResourceDto": {
+        "type": "object",
+        "properties": {}
+      },
+      "LinkResourceUserDto": {
         "type": "object",
         "properties": {}
       },

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -74,6 +74,33 @@
         "tags": [
           "users"
         ]
+      },
+      "post": {
+        "operationId": "UsersController_adminCreate",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateUserAdminDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "users"
+        ]
       }
     },
     "/users/{id}": {
@@ -1797,6 +1824,10 @@
       }
     },
     "schemas": {
+      "CreateUserAdminDto": {
+        "type": "object",
+        "properties": {}
+      },
       "UpdateUserAdminDto": {
         "type": "object",
         "properties": {}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-workgroup/api",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "private": true,
   "description": "Project-Workgroup backend API",
   "scripts": {

--- a/apps/api/prisma/migrations/20260703203525_add_resources_and_user_status/migration.sql
+++ b/apps/api/prisma/migrations/20260703203525_add_resources_and_user_status/migration.sql
@@ -1,0 +1,36 @@
+-- CreateEnum
+CREATE TYPE "ResourceKind" AS ENUM ('user', 'placeholder');
+
+-- CreateEnum
+CREATE TYPE "ResourceStatus" AS ENUM ('active', 'inactive');
+
+-- CreateEnum
+CREATE TYPE "UserStatus" AS ENUM ('active', 'disabled');
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "status" "UserStatus" NOT NULL DEFAULT 'active';
+
+-- CreateTable
+CREATE TABLE "resources" (
+    "id" BIGSERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT,
+    "kind" "ResourceKind" NOT NULL DEFAULT 'placeholder',
+    "status" "ResourceStatus" NOT NULL DEFAULT 'active',
+    "user_id" BIGINT,
+    "avatar_url" TEXT,
+    "discipline" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "resources_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "resources_user_id_key" ON "resources"("user_id");
+
+-- CreateIndex
+CREATE INDEX "resources_kind_status_idx" ON "resources"("kind", "status");
+
+-- AddForeignKey
+ALTER TABLE "resources" ADD CONSTRAINT "resources_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/20260703203526_backfill_resources_from_users/migration.sql
+++ b/apps/api/prisma/migrations/20260703203526_backfill_resources_from_users/migration.sql
@@ -1,0 +1,14 @@
+-- Backfill: crea un resource enlazado (kind='user') por cada usuario existente,
+-- estableciendo la invariante "cada user real tiene 1 resource".
+-- Idempotente: no duplica si el usuario ya tiene resource.
+INSERT INTO "resources" ("name", "email", "kind", "status", "user_id", "avatar_url", "updated_at")
+SELECT
+  u."display_name",
+  u."email",
+  'user'::"ResourceKind",
+  CASE WHEN u."status" = 'disabled' THEN 'inactive'::"ResourceStatus" ELSE 'active'::"ResourceStatus" END,
+  u."id",
+  u."avatar_url",
+  NOW()
+FROM "users" u
+WHERE NOT EXISTS (SELECT 1 FROM "resources" r WHERE r."user_id" = u."id");

--- a/apps/api/prisma/migrations/20260703203630_repoint_task_assignee_to_resources/migration.sql
+++ b/apps/api/prisma/migrations/20260703203630_repoint_task_assignee_to_resources/migration.sql
@@ -1,0 +1,33 @@
+-- Repoint tasks.assignee_id de users → resources.
+-- assignee_id guardaba users.id; hay que remapearlo al resource enlazado (resources.user_id)
+-- mientras el FK está caído. La migración de backfill previa garantiza que todo user tiene resource.
+
+-- DropForeignKey
+ALTER TABLE "tasks" DROP CONSTRAINT "tasks_assignee_id_fkey";
+
+-- Anula (avisando) los assignees sin resource enlazado ANTES de remapear: así un users.id
+-- residual nunca se confunde con un resources.id válido de otra entidad. No debería ocurrir
+-- gracias al backfill; es una red de seguridad.
+DO $$
+DECLARE orphaned INT;
+BEGIN
+  SELECT count(*) INTO orphaned FROM "tasks" t
+  WHERE t."assignee_id" IS NOT NULL
+    AND NOT EXISTS (SELECT 1 FROM "resources" r WHERE r."user_id" = t."assignee_id");
+  IF orphaned > 0 THEN
+    RAISE WARNING 'tasks: % assignee_id sin resource enlazado; se anulan', orphaned;
+    UPDATE "tasks" t SET "assignee_id" = NULL
+    WHERE t."assignee_id" IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM "resources" r WHERE r."user_id" = t."assignee_id");
+  END IF;
+END $$;
+
+-- Remap users.id → resources.id vía el puente resources.user_id
+UPDATE "tasks" t
+SET "assignee_id" = r."id"
+FROM "resources" r
+WHERE r."user_id" = t."assignee_id"
+  AND t."assignee_id" IS NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_assignee_id_fkey" FOREIGN KEY ("assignee_id") REFERENCES "resources"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/20260703203730_repoint_workload_to_resources/migration.sql
+++ b/apps/api/prisma/migrations/20260703203730_repoint_workload_to_resources/migration.sql
@@ -1,0 +1,37 @@
+-- Repoint workload de users → resources. Renombra la columna (preserva datos) y remapea
+-- los valores users.id → resources.id vía el puente resources.user_id. resource_id es NOT NULL,
+-- así que los huérfanos (sin resource enlazado) se eliminan en vez de anularse.
+
+-- Renombra la columna: los índices que la referencian la siguen automáticamente.
+ALTER TABLE "workload" RENAME COLUMN "user_id" TO "resource_id";
+
+-- El FK aún apunta a users; lo quitamos para remapear.
+ALTER TABLE "workload" DROP CONSTRAINT "workload_user_id_fkey";
+
+-- Elimina (avisando) las filas sin resource enlazado ANTES de remapear, para no confundir
+-- un users.id residual con un resources.id válido de otra entidad. No debería ocurrir gracias
+-- al backfill; es una red de seguridad.
+DO $$
+DECLARE orphaned INT;
+BEGIN
+  SELECT count(*) INTO orphaned FROM "workload" w
+  WHERE NOT EXISTS (SELECT 1 FROM "resources" r WHERE r."user_id" = w."resource_id");
+  IF orphaned > 0 THEN
+    RAISE WARNING 'workload: % filas sin resource enlazado; se eliminan', orphaned;
+    DELETE FROM "workload" w
+    WHERE NOT EXISTS (SELECT 1 FROM "resources" r WHERE r."user_id" = w."resource_id");
+  END IF;
+END $$;
+
+-- Remap users.id → resources.id vía el puente resources.user_id.
+UPDATE "workload" w
+SET "resource_id" = r."id"
+FROM "resources" r
+WHERE r."user_id" = w."resource_id";
+
+-- Renombra el índice para que cuadre con el nombre por defecto que Prisma espera.
+-- El índice único (workload_task_user_date_unique) conserva su nombre y sigue a la columna.
+ALTER INDEX "workload_user_id_date_idx" RENAME TO "workload_resource_id_date_idx";
+
+-- FK nuevo hacia resources.
+ALTER TABLE "workload" ADD CONSTRAINT "workload_resource_id_fkey" FOREIGN KEY ("resource_id") REFERENCES "resources"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -63,6 +63,21 @@ enum CalendarScope {
   project
 }
 
+enum ResourceKind {
+  user
+  placeholder
+}
+
+enum ResourceStatus {
+  active
+  inactive
+}
+
+enum UserStatus {
+  active
+  disabled
+}
+
 // ─── Models ───────────────────────────────────────────────────────────────────
 
 model User {
@@ -71,17 +86,37 @@ model User {
   email       String     @unique
   displayName String     @map("display_name")
   role        GlobalRole @default(member)
+  status      UserStatus @default(active)
   avatarUrl   String?    @map("avatar_url")
   createdAt   DateTime   @default(now()) @map("created_at")
   updatedAt   DateTime   @updatedAt @map("updated_at")
 
   ownedProjects      Project[]       @relation("ProjectOwner")
   projectMemberships ProjectMember[]
-  assignedTasks      Task[]          @relation("TaskAssignee")
-  workload           Workload[]
   apiKeys            ApiKey[]
+  resource           Resource?
 
   @@map("users")
+}
+
+model Resource {
+  id         BigInt         @id @default(autoincrement())
+  name       String
+  email      String?
+  kind       ResourceKind   @default(placeholder)
+  status     ResourceStatus @default(active)
+  userId     BigInt?        @unique @map("user_id")
+  avatarUrl  String?        @map("avatar_url")
+  discipline String?
+  createdAt  DateTime       @default(now()) @map("created_at")
+  updatedAt  DateTime       @updatedAt @map("updated_at")
+
+  user          User?      @relation(fields: [userId], references: [id], onDelete: SetNull)
+  assignedTasks Task[]     @relation("TaskAssignee")
+  workload      Workload[]
+
+  @@index([kind, status])
+  @@map("resources")
 }
 
 model Project {
@@ -161,7 +196,7 @@ model Task {
   project  Project    @relation(fields: [projectId], references: [id], onDelete: Cascade)
   parent   Task?      @relation("TaskChildren", fields: [parentId], references: [id], onDelete: Cascade)
   children Task[]     @relation("TaskChildren")
-  assignee User?      @relation("TaskAssignee", fields: [assigneeId], references: [id], onDelete: SetNull)
+  assignee Resource?  @relation("TaskAssignee", fields: [assigneeId], references: [id], onDelete: SetNull)
   linksOut TaskLink[] @relation("LinkSource")
   linksIn  TaskLink[] @relation("LinkTarget")
   workload Workload[]
@@ -195,7 +230,7 @@ model TaskLink {
 
 model Workload {
   id             BigInt   @id @default(autoincrement())
-  userId         BigInt   @map("user_id")
+  resourceId     BigInt   @map("resource_id")
   taskId         BigInt   @map("task_id")
   projectId      BigInt   @map("project_id")
   date           DateTime @db.Date
@@ -204,11 +239,12 @@ model Workload {
   createdAt      DateTime @default(now()) @map("created_at")
   updatedAt      DateTime @updatedAt @map("updated_at")
 
-  user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
-  task    Task    @relation(fields: [taskId], references: [id], onDelete: Cascade)
-  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  resource Resource @relation(fields: [resourceId], references: [id], onDelete: Cascade)
+  task     Task     @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  project  Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
-  @@index([userId, date])
+  @@unique([taskId, resourceId, date], map: "workload_task_user_date_unique")
+  @@index([resourceId, date])
   @@index([projectId, date])
   @@map("workload")
 }

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -8,7 +8,7 @@ async function main() {
   const firebaseUid = process.env.SEED_ADMIN_UID ?? 'dev-admin-placeholder';
   const email = process.env.SEED_ADMIN_EMAIL ?? 'admin@example.local';
 
-  await prisma.user.upsert({
+  const admin = await prisma.user.upsert({
     where: { firebaseUid },
     update: { role: 'admin' },
     create: {
@@ -19,7 +19,19 @@ async function main() {
     },
   });
 
-  console.log('Seeded admin user');
+  // Mantiene la invariante "cada user real tiene un resource enlazado".
+  await prisma.resource.upsert({
+    where: { userId: admin.id },
+    update: {},
+    create: {
+      name: admin.displayName,
+      email: admin.email,
+      kind: 'user',
+      userId: admin.id,
+    },
+  });
+
+  console.log('Seeded admin user and resource');
 }
 
 main()

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -11,6 +11,7 @@ import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
 import { ProjectsModule } from './projects/projects.module';
 import { ProjectMembersModule } from './project-members/project-members.module';
+import { ResourcesModule } from './resources/resources.module';
 import { TasksModule } from './tasks/tasks.module';
 import { TaskLinksModule } from './task-links/task-links.module';
 import { WorkloadModule } from './workload/workload.module';
@@ -66,6 +67,7 @@ const isProd = process.env.NODE_ENV === 'production';
     UsersModule,
     ProjectsModule,
     ProjectMembersModule,
+    ResourcesModule,
     TasksModule,
     TaskLinksModule,
     WorkloadModule,

--- a/apps/api/src/auth/auth.guard.ts
+++ b/apps/api/src/auth/auth.guard.ts
@@ -105,6 +105,7 @@ export class AuthGuard implements CanActivate {
         where: { firebaseUid: decoded.uid },
       });
       if (!user) return null;
+      if (user.status === 'disabled') return null;
       return {
         id: user.id,
         firebaseUid: user.firebaseUid,
@@ -131,6 +132,7 @@ export class AuthGuard implements CanActivate {
         where: { id: BigInt(payload.sub) },
       });
       if (!user) return null;
+      if (user.status === 'disabled') return null;
       const scope =
         typeof payload.scope === 'string' ? payload.scope : undefined;
       return {
@@ -157,6 +159,7 @@ export class AuthGuard implements CanActivate {
     });
     for (const cand of candidates) {
       if (await argon2.verify(cand.keyHash, token)) {
+        if (cand.user.status === 'disabled') return null;
         await this.prisma.apiKey.update({
           where: { id: cand.id },
           data: { lastUsedAt: new Date() },

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -13,21 +13,45 @@ export class AuthService {
     const decoded = await this.firebase.verifyIdToken(token).catch(() => {
       throw new UnauthorizedException('invalid id token');
     });
-    const user = await this.prisma.user.upsert({
-      where: { firebaseUid: decoded.uid },
-      update: {
-        email: decoded.email ?? undefined,
-        displayName: decoded.name ?? decoded.email ?? 'User',
-        avatarUrl: decoded.picture ?? undefined,
-      },
-      create: {
-        firebaseUid: decoded.uid,
-        email: decoded.email ?? `${decoded.uid}@unknown.local`,
-        displayName: decoded.name ?? decoded.email ?? 'User',
-        avatarUrl: decoded.picture ?? undefined,
-        role: 'member',
-      },
+    const displayName = decoded.name ?? decoded.email ?? 'User';
+    const avatarUrl = decoded.picture ?? undefined;
+
+    return this.prisma.$transaction(async (tx) => {
+      const user = await tx.user.upsert({
+        where: { firebaseUid: decoded.uid },
+        update: {
+          email: decoded.email ?? undefined,
+          displayName,
+          avatarUrl,
+        },
+        create: {
+          firebaseUid: decoded.uid,
+          email: decoded.email ?? `${decoded.uid}@unknown.local`,
+          displayName,
+          avatarUrl,
+          role: 'member',
+        },
+      });
+
+      // Invariante: cada user real tiene un resource enlazado (kind='user'). Se crea
+      // al alta y se mantiene sincronizado con el perfil de Firebase en cada login.
+      await tx.resource.upsert({
+        where: { userId: user.id },
+        update: {
+          name: user.displayName,
+          email: user.email,
+          avatarUrl: user.avatarUrl,
+        },
+        create: {
+          name: user.displayName,
+          email: user.email,
+          avatarUrl: user.avatarUrl,
+          kind: 'user',
+          userId: user.id,
+        },
+      });
+
+      return user;
     });
-    return user;
   }
 }

--- a/apps/api/src/calendar/task-rescheduler.service.ts
+++ b/apps/api/src/calendar/task-rescheduler.service.ts
@@ -79,7 +79,7 @@ export class TaskReschedulerService {
         if (t.assigneeId && result.workload.length > 0) {
           await tx.workload.createMany({
             data: result.workload.map((slot) => ({
-              userId: t.assigneeId!,
+              resourceId: t.assigneeId!,
               taskId: t.id,
               projectId,
               date: slot.date,

--- a/apps/api/src/firebase/firebase.service.ts
+++ b/apps/api/src/firebase/firebase.service.ts
@@ -27,4 +27,27 @@ export class FirebaseService implements OnModuleInit {
     if (!this.app) throw new Error('Firebase not initialized');
     return this.app.auth().verifyIdToken(token);
   }
+
+  async createUser(input: {
+    email: string;
+    password: string;
+    displayName: string;
+  }): Promise<string> {
+    if (!this.app) throw new Error('Firebase not initialized');
+    const rec = await this.app.auth().createUser({
+      email: input.email,
+      password: input.password,
+      displayName: input.displayName,
+    });
+    return rec.uid;
+  }
+
+  // Compensación: borra el usuario de Firebase si la transacción DB falla tras crearlo.
+  async deleteUser(uid: string): Promise<void> {
+    if (!this.app) return;
+    await this.app
+      .auth()
+      .deleteUser(uid)
+      .catch(() => undefined);
+  }
 }

--- a/apps/api/src/project-members/project-members.controller.ts
+++ b/apps/api/src/project-members/project-members.controller.ts
@@ -5,11 +5,15 @@ import {
   Get,
   HttpCode,
   Param,
+  Patch,
   Post,
   UseGuards,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
-import { AddProjectMemberDto } from '@project-workgroup/shared';
+import {
+  AddProjectMemberDto,
+  UpdateProjectMemberDto,
+} from '@project-workgroup/shared';
 import { AuthGuard } from '../auth/auth.guard';
 import { ProjectMembershipGuard } from '../auth/project-membership.guard';
 import { RequireProject } from '../auth/require-project.decorator';
@@ -35,6 +39,16 @@ export class ProjectMembersController {
   @Get()
   async list(@Param('projectId') projectId: string) {
     return this.members.list(BigInt(projectId));
+  }
+
+  @Patch(':userId')
+  @RequireProject('projectId', { minRole: 'manager' })
+  async updateRole(
+    @Param('projectId') projectId: string,
+    @Param('userId') userId: string,
+    @Body() dto: UpdateProjectMemberDto,
+  ) {
+    return this.members.updateRole(BigInt(projectId), BigInt(userId), dto.projectRole);
   }
 
   @Delete(':userId')

--- a/apps/api/src/project-members/project-members.controller.ts
+++ b/apps/api/src/project-members/project-members.controller.ts
@@ -48,7 +48,11 @@ export class ProjectMembersController {
     @Param('userId') userId: string,
     @Body() dto: UpdateProjectMemberDto,
   ) {
-    return this.members.updateRole(BigInt(projectId), BigInt(userId), dto.projectRole);
+    return this.members.updateRole(
+      BigInt(projectId),
+      BigInt(userId),
+      dto.projectRole,
+    );
   }
 
   @Delete(':userId')

--- a/apps/api/src/project-members/project-members.service.ts
+++ b/apps/api/src/project-members/project-members.service.ts
@@ -18,11 +18,27 @@ export class ProjectMembersService {
     userId: bigint;
     projectRole: string;
     createdAt: Date;
+    user: {
+      id: bigint;
+      email: string;
+      displayName: string;
+      role: string;
+      status: string;
+      avatarUrl: string | null;
+    };
   }): ProjectMemberResponse {
     return {
       projectId: m.projectId.toString(),
       userId: m.userId.toString(),
       projectRole: m.projectRole as ProjectMemberResponse['projectRole'],
+      user: {
+        id: m.user.id.toString(),
+        email: m.user.email,
+        displayName: m.user.displayName,
+        role: m.user.role as ProjectMemberResponse['user']['role'],
+        status: m.user.status as ProjectMemberResponse['user']['status'],
+        avatarUrl: m.user.avatarUrl,
+      },
       createdAt: m.createdAt.toISOString(),
     };
   }
@@ -43,6 +59,7 @@ export class ProjectMembersService {
 
     const member = await this.prisma.projectMember.create({
       data: { projectId, userId, projectRole: dto.projectRole },
+      include: { user: true },
     });
     return this.toResponse(member);
   }
@@ -51,8 +68,26 @@ export class ProjectMembersService {
     const members = await this.prisma.projectMember.findMany({
       where: { projectId },
       orderBy: { createdAt: 'asc' },
+      include: { user: true },
     });
     return members.map((m) => this.toResponse(m));
+  }
+
+  async updateRole(
+    projectId: bigint,
+    userId: bigint,
+    projectRole: AddProjectMemberDto['projectRole'],
+  ): Promise<ProjectMemberResponse> {
+    const member = await this.prisma.projectMember.findUnique({
+      where: { projectId_userId: { projectId, userId } },
+    });
+    if (!member) throw new NotFoundException('member not found');
+    const updated = await this.prisma.projectMember.update({
+      where: { projectId_userId: { projectId, userId } },
+      data: { projectRole },
+      include: { user: true },
+    });
+    return this.toResponse(updated);
   }
 
   async remove(projectId: bigint, userId: bigint): Promise<void> {

--- a/apps/api/src/resources/resources.controller.ts
+++ b/apps/api/src/resources/resources.controller.ts
@@ -1,0 +1,72 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import {
+  CreateResourceDto,
+  LinkResourceUserDto,
+  ListResourcesQueryDto,
+  UpdateResourceDto,
+} from '@project-workgroup/shared';
+import { AuthGuard } from '../auth/auth.guard';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { ResourcesService } from './resources.service';
+
+@ApiTags('resources')
+@ApiBearerAuth()
+@UseGuards(AuthGuard)
+@Controller({ path: 'resources', version: '1' })
+export class ResourcesController {
+  constructor(private readonly resources: ResourcesService) {}
+
+  // Lectura abierta a cualquier autenticado: el selector de responsable del Gantt
+  // la necesita para miembros no-admin. Las mutaciones son admin-only.
+  @Get()
+  async list(@Query() q: ListResourcesQueryDto) {
+    return this.resources.list(q);
+  }
+
+  @Get(':id')
+  async getById(@Param('id') id: string) {
+    return this.resources.getById(BigInt(id));
+  }
+
+  @Post()
+  @UseGuards(RolesGuard)
+  @Roles('admin')
+  async create(@Body() dto: CreateResourceDto) {
+    return this.resources.create(dto);
+  }
+
+  @Patch(':id')
+  @UseGuards(RolesGuard)
+  @Roles('admin')
+  async update(@Param('id') id: string, @Body() dto: UpdateResourceDto) {
+    return this.resources.update(BigInt(id), dto);
+  }
+
+  @Patch(':id/link-user')
+  @UseGuards(RolesGuard)
+  @Roles('admin')
+  async linkUser(@Param('id') id: string, @Body() dto: LinkResourceUserDto) {
+    return this.resources.linkToUser(BigInt(id), BigInt(dto.userId));
+  }
+
+  @Delete(':id')
+  @HttpCode(204)
+  @UseGuards(RolesGuard)
+  @Roles('admin')
+  async remove(@Param('id') id: string) {
+    await this.resources.remove(BigInt(id));
+  }
+}

--- a/apps/api/src/resources/resources.module.ts
+++ b/apps/api/src/resources/resources.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ResourcesController } from './resources.controller';
+import { ResourcesService } from './resources.service';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [ResourcesController],
+  providers: [ResourcesService],
+  exports: [ResourcesService],
+})
+export class ResourcesModule {}

--- a/apps/api/src/resources/resources.service.spec.ts
+++ b/apps/api/src/resources/resources.service.spec.ts
@@ -1,0 +1,295 @@
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { ResourcesService } from './resources.service';
+
+const resourceRow = (overrides: Partial<any> = {}) => ({
+  id: 1n,
+  name: 'Resource',
+  email: null,
+  kind: 'placeholder',
+  status: 'active',
+  userId: null,
+  avatarUrl: null,
+  discipline: null,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  ...overrides,
+});
+
+describe('ResourcesService', () => {
+  const makePrisma = () => ({
+    resource: {
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      findUnique: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  });
+
+  const makeService = (prisma: ReturnType<typeof makePrisma>) =>
+    new ResourcesService(prisma as any);
+
+  describe('create', () => {
+    it('forces kind to placeholder even though the dto has no kind field', async () => {
+      const prisma = makePrisma();
+      prisma.resource.create.mockResolvedValue(resourceRow());
+      const service = makeService(prisma);
+
+      await service.create({ name: 'New resource' } as any);
+
+      expect(prisma.resource.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ kind: 'placeholder' }),
+        }),
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('ignores name/email/avatarUrl on a user-linked resource but applies discipline/status', async () => {
+      const prisma = makePrisma();
+      prisma.resource.findUnique.mockResolvedValue(
+        resourceRow({ kind: 'user', userId: 5n }),
+      );
+      prisma.resource.update.mockResolvedValue(resourceRow({ kind: 'user' }));
+      const service = makeService(prisma);
+
+      await service.update(1n, {
+        name: 'Ignored name',
+        email: 'ignored@example.com',
+        avatarUrl: 'https://ignored.example/avatar.png',
+        discipline: 'Engineering',
+        status: 'inactive',
+      });
+
+      expect(prisma.resource.update).toHaveBeenCalledWith({
+        where: { id: 1n },
+        data: {
+          name: undefined,
+          email: undefined,
+          avatarUrl: undefined,
+          discipline: 'Engineering',
+          status: 'inactive',
+        },
+      });
+    });
+
+    it('applies name/email/avatarUrl on a placeholder resource', async () => {
+      const prisma = makePrisma();
+      prisma.resource.findUnique.mockResolvedValue(
+        resourceRow({ kind: 'placeholder' }),
+      );
+      prisma.resource.update.mockResolvedValue(
+        resourceRow({ name: 'Updated name' }),
+      );
+      const service = makeService(prisma);
+
+      await service.update(1n, {
+        name: 'Updated name',
+        email: 'placeholder@example.com',
+      });
+
+      expect(prisma.resource.update).toHaveBeenCalledWith({
+        where: { id: 1n },
+        data: {
+          name: 'Updated name',
+          email: 'placeholder@example.com',
+          avatarUrl: undefined,
+          discipline: undefined,
+          status: undefined,
+        },
+      });
+    });
+
+    it('throws NotFoundException when the resource does not exist', async () => {
+      const prisma = makePrisma();
+      prisma.resource.findUnique.mockResolvedValue(null);
+      const service = makeService(prisma);
+
+      await expect(
+        service.update(99n, { name: 'anything' }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('remove', () => {
+    it('throws BadRequestException when the resource is not a placeholder', async () => {
+      const prisma = makePrisma();
+      prisma.resource.findUnique.mockResolvedValue(
+        resourceRow({
+          kind: 'user',
+          _count: { assignedTasks: 0, workload: 0 },
+        }),
+      );
+      const service = makeService(prisma);
+
+      await expect(service.remove(1n)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      expect(prisma.resource.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws ConflictException when the placeholder has assigned tasks', async () => {
+      const prisma = makePrisma();
+      prisma.resource.findUnique.mockResolvedValue(
+        resourceRow({
+          kind: 'placeholder',
+          _count: { assignedTasks: 2, workload: 0 },
+        }),
+      );
+      const service = makeService(prisma);
+
+      await expect(service.remove(1n)).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+      expect(prisma.resource.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws ConflictException when the placeholder has workload', async () => {
+      const prisma = makePrisma();
+      prisma.resource.findUnique.mockResolvedValue(
+        resourceRow({
+          kind: 'placeholder',
+          _count: { assignedTasks: 0, workload: 3 },
+        }),
+      );
+      const service = makeService(prisma);
+
+      await expect(service.remove(1n)).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+      expect(prisma.resource.delete).not.toHaveBeenCalled();
+    });
+
+    it('deletes a placeholder without references', async () => {
+      const prisma = makePrisma();
+      prisma.resource.findUnique.mockResolvedValue(
+        resourceRow({
+          kind: 'placeholder',
+          _count: { assignedTasks: 0, workload: 0 },
+        }),
+      );
+      const service = makeService(prisma);
+
+      await service.remove(1n);
+
+      expect(prisma.resource.delete).toHaveBeenCalledWith({
+        where: { id: 1n },
+      });
+    });
+
+    it('throws NotFoundException when the resource does not exist', async () => {
+      const prisma = makePrisma();
+      prisma.resource.findUnique.mockResolvedValue(null);
+      const service = makeService(prisma);
+
+      await expect(service.remove(1n)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('linkToUser', () => {
+    // El $transaction del service recibe un callback; lo ejecutamos contra un tx mock propio.
+    const makeTx = () => ({
+      resource: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+      user: {
+        findUnique: jest.fn(),
+      },
+      task: {
+        updateMany: jest.fn(),
+      },
+      workload: {
+        updateMany: jest.fn(),
+      },
+    });
+
+    it('merges the user auto-generated resource into the placeholder and links it', async () => {
+      const prisma = makePrisma();
+      const tx = makeTx();
+      prisma.$transaction.mockImplementation((fn: any) => fn(tx));
+      const service = makeService(prisma);
+
+      const placeholderId = 1n;
+      const userId = 5n;
+      const userResourceId = 2n;
+
+      tx.resource.findUnique
+        .mockResolvedValueOnce(
+          resourceRow({ id: placeholderId, kind: 'placeholder' }),
+        ) // lookup por id (placeholder objetivo)
+        .mockResolvedValueOnce(
+          resourceRow({ id: userResourceId, userId, kind: 'user' }),
+        ); // lookup por userId (resource auto-generado, id distinto)
+      tx.user.findUnique.mockResolvedValue({
+        id: userId,
+        email: 'user@example.com',
+      });
+      tx.resource.update.mockResolvedValue(
+        resourceRow({
+          id: placeholderId,
+          kind: 'user',
+          userId,
+          email: 'user@example.com',
+        }),
+      );
+
+      await service.linkToUser(placeholderId, userId);
+
+      expect(tx.task.updateMany).toHaveBeenCalledWith({
+        where: { assigneeId: userResourceId },
+        data: { assigneeId: placeholderId },
+      });
+      expect(tx.workload.updateMany).toHaveBeenCalledWith({
+        where: { resourceId: userResourceId },
+        data: { resourceId: placeholderId },
+      });
+      expect(tx.resource.delete).toHaveBeenCalledWith({
+        where: { id: userResourceId },
+      });
+      expect(tx.resource.update).toHaveBeenCalledWith({
+        where: { id: placeholderId },
+        data: { kind: 'user', userId, email: 'user@example.com' },
+      });
+    });
+
+    it('throws BadRequestException when the target resource is not a placeholder', async () => {
+      const prisma = makePrisma();
+      const tx = makeTx();
+      prisma.$transaction.mockImplementation((fn: any) => fn(tx));
+      tx.resource.findUnique.mockResolvedValueOnce(
+        resourceRow({ id: 1n, kind: 'user' }),
+      );
+      const service = makeService(prisma);
+
+      await expect(service.linkToUser(1n, 5n)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      expect(tx.user.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when the user does not exist', async () => {
+      const prisma = makePrisma();
+      const tx = makeTx();
+      prisma.$transaction.mockImplementation((fn: any) => fn(tx));
+      tx.resource.findUnique.mockResolvedValueOnce(
+        resourceRow({ id: 1n, kind: 'placeholder' }),
+      );
+      tx.user.findUnique.mockResolvedValue(null);
+      const service = makeService(prisma);
+
+      await expect(service.linkToUser(1n, 5n)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+      expect(tx.resource.update).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/resources/resources.service.ts
+++ b/apps/api/src/resources/resources.service.ts
@@ -1,0 +1,166 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import {
+  CreateResourceDto,
+  ListResourcesQueryDto,
+  ResourceResponse,
+  UpdateResourceDto,
+} from '@project-workgroup/shared';
+
+@Injectable()
+export class ResourcesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  private toResponse(r: {
+    id: bigint;
+    name: string;
+    email: string | null;
+    kind: string;
+    status: string;
+    userId: bigint | null;
+    avatarUrl: string | null;
+    discipline: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }): ResourceResponse {
+    return {
+      id: r.id.toString(),
+      name: r.name,
+      email: r.email,
+      kind: r.kind as ResourceResponse['kind'],
+      status: r.status as ResourceResponse['status'],
+      userId: r.userId ? r.userId.toString() : null,
+      avatarUrl: r.avatarUrl,
+      discipline: r.discipline,
+      createdAt: r.createdAt.toISOString(),
+      updatedAt: r.updatedAt.toISOString(),
+    };
+  }
+
+  async list(q: ListResourcesQueryDto) {
+    const take = Math.min(q.limit ?? 25, 100);
+    const where: any = {};
+    if (q.search) {
+      where.OR = [
+        { name: { contains: q.search, mode: 'insensitive' as const } },
+        { email: { contains: q.search, mode: 'insensitive' as const } },
+      ];
+    }
+    if (q.kind) where.kind = q.kind;
+    if (q.status) where.status = q.status;
+    const cursor = q.cursor ? { id: BigInt(q.cursor) } : undefined;
+    const rows = await this.prisma.resource.findMany({
+      where,
+      take: take + 1,
+      cursor,
+      skip: cursor ? 1 : 0,
+      orderBy: { id: 'asc' },
+    });
+    const hasMore = rows.length > take;
+    const items = (hasMore ? rows.slice(0, -1) : rows).map((r) =>
+      this.toResponse(r),
+    );
+    return { items, nextCursor: hasMore ? items[items.length - 1].id : null };
+  }
+
+  async getById(id: bigint): Promise<ResourceResponse> {
+    const resource = await this.prisma.resource.findUnique({ where: { id } });
+    if (!resource) throw new NotFoundException('resource not found');
+    return this.toResponse(resource);
+  }
+
+  async create(dto: CreateResourceDto): Promise<ResourceResponse> {
+    // Este endpoint solo crea placeholders; el resource de un usuario real se
+    // crea en auth.sync, no aquí.
+    const resource = await this.prisma.resource.create({
+      data: {
+        name: dto.name,
+        email: dto.email ?? null,
+        avatarUrl: dto.avatarUrl ?? null,
+        discipline: dto.discipline ?? null,
+        kind: 'placeholder',
+      },
+    });
+    return this.toResponse(resource);
+  }
+
+  async update(id: bigint, dto: UpdateResourceDto): Promise<ResourceResponse> {
+    const resource = await this.prisma.resource.findUnique({ where: { id } });
+    if (!resource) throw new NotFoundException('resource not found');
+    // En resources enlazados a un user, name/email/avatarUrl los gobierna el perfil
+    // (auth.sync los re-sincroniza en cada login), así que aquí son de solo lectura:
+    // el admin solo ajusta discipline/status. En placeholders todo es editable.
+    const isUserLinked = resource.kind === 'user';
+    const updated = await this.prisma.resource.update({
+      where: { id },
+      data: {
+        name: isUserLinked ? undefined : dto.name ?? undefined,
+        email: isUserLinked ? undefined : dto.email ?? undefined,
+        avatarUrl: isUserLinked ? undefined : dto.avatarUrl ?? undefined,
+        discipline: dto.discipline ?? undefined,
+        status: dto.status ?? undefined,
+      },
+    });
+    return this.toResponse(updated);
+  }
+
+  async linkToUser(
+    resourceId: bigint,
+    userId: bigint,
+  ): Promise<ResourceResponse> {
+    return this.prisma.$transaction(async (tx) => {
+      const placeholder = await tx.resource.findUnique({
+        where: { id: resourceId },
+      });
+      if (!placeholder) throw new NotFoundException('resource not found');
+      if (placeholder.kind !== 'placeholder')
+        throw new BadRequestException('resource is not a placeholder');
+
+      const user = await tx.user.findUnique({ where: { id: userId } });
+      if (!user) throw new NotFoundException('user not found');
+
+      // El user ya trae su resource auto-generado (invariante de auth.sync): hay
+      // que fusionar los dos. Reasignamos su trabajo al placeholder y lo borramos.
+      // Tareas y workload de ambos son disjuntos por task (una tarea tiene un solo
+      // assignee), así que el traspaso no colisiona con el índice único de workload.
+      const userResource = await tx.resource.findUnique({ where: { userId } });
+      if (userResource && userResource.id !== resourceId) {
+        await tx.task.updateMany({
+          where: { assigneeId: userResource.id },
+          data: { assigneeId: resourceId },
+        });
+        await tx.workload.updateMany({
+          where: { resourceId: userResource.id },
+          data: { resourceId },
+        });
+        await tx.resource.delete({ where: { id: userResource.id } });
+      }
+
+      const linked = await tx.resource.update({
+        where: { id: resourceId },
+        data: { kind: 'user', userId, email: user.email },
+      });
+      return this.toResponse(linked);
+    });
+  }
+
+  async remove(id: bigint): Promise<void> {
+    const resource = await this.prisma.resource.findUnique({
+      where: { id },
+      include: { _count: { select: { assignedTasks: true, workload: true } } },
+    });
+    if (!resource) throw new NotFoundException('resource not found');
+    if (resource.kind !== 'placeholder')
+      throw new BadRequestException('only placeholder resources can be deleted');
+    if (resource._count.assignedTasks > 0 || resource._count.workload > 0)
+      throw new ConflictException(
+        'resource has assigned tasks or workload; reassign them first',
+      );
+    await this.prisma.resource.delete({ where: { id } });
+  }
+}

--- a/apps/api/src/resources/resources.service.ts
+++ b/apps/api/src/resources/resources.service.ts
@@ -99,9 +99,9 @@ export class ResourcesService {
     const updated = await this.prisma.resource.update({
       where: { id },
       data: {
-        name: isUserLinked ? undefined : dto.name ?? undefined,
-        email: isUserLinked ? undefined : dto.email ?? undefined,
-        avatarUrl: isUserLinked ? undefined : dto.avatarUrl ?? undefined,
+        name: isUserLinked ? undefined : (dto.name ?? undefined),
+        email: isUserLinked ? undefined : (dto.email ?? undefined),
+        avatarUrl: isUserLinked ? undefined : (dto.avatarUrl ?? undefined),
         discipline: dto.discipline ?? undefined,
         status: dto.status ?? undefined,
       },
@@ -156,7 +156,9 @@ export class ResourcesService {
     });
     if (!resource) throw new NotFoundException('resource not found');
     if (resource.kind !== 'placeholder')
-      throw new BadRequestException('only placeholder resources can be deleted');
+      throw new BadRequestException(
+        'only placeholder resources can be deleted',
+      );
     if (resource._count.assignedTasks > 0 || resource._count.workload > 0)
       throw new ConflictException(
         'resource has assigned tasks or workload; reassign them first',

--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -223,7 +223,7 @@ export class TasksService {
     if (!assigneeId || workload.length === 0) return;
     await tx.workload.createMany({
       data: workload.map((slot) => ({
-        userId: assigneeId,
+        resourceId: assigneeId,
         taskId,
         projectId,
         date: slot.date,
@@ -311,20 +311,27 @@ export class TasksService {
     }
   }
 
-  private async resolveAssigneeId(
+  // assigneeId apunta a un resource (entidad asignable), no a un user. Solo se
+  // permite asignar a resources activos; las asignaciones previas a uno que luego
+  // se desactive se conservan.
+  private async resolveResourceId(
     assigneeId?: string,
   ): Promise<bigint | null | undefined> {
     if (assigneeId === undefined) return undefined;
     if (!assigneeId) return null;
 
     const id = this.parseBigInt(assigneeId, 'assigneeId');
-    const user = await this.prisma.user.findUnique({
+    const resource = await this.prisma.resource.findUnique({
       where: { id },
-      select: { id: true },
+      select: { status: true },
     });
-    if (!user)
+    if (!resource)
       throw new BadRequestException(
-        'assigneeId must reference an existing user',
+        'assigneeId must reference an existing resource',
+      );
+    if (resource.status !== 'active')
+      throw new BadRequestException(
+        'assigneeId must reference an active resource',
       );
     return id;
   }
@@ -440,7 +447,7 @@ export class TasksService {
   async create(projectId: bigint, dto: CreateTaskDto): Promise<TaskResponse> {
     const startedAt = Date.now();
     const parentId = await this.validateParent(projectId, null, dto.parentId);
-    const assigneeId = await this.resolveAssigneeId(dto.assigneeId);
+    const assigneeId = await this.resolveResourceId(dto.assigneeId);
     const order = await this.resolveNeighborOrders(projectId, dto.afterTaskId);
     const schedule = await this.computeSchedule(
       projectId,
@@ -544,7 +551,7 @@ export class TasksService {
       id,
       dto.parentId,
     );
-    const assigneeId = await this.resolveAssigneeId(dto.assigneeId);
+    const assigneeId = await this.resolveResourceId(dto.assigneeId);
     const finalAssigneeId =
       assigneeId !== undefined ? assigneeId : existing.assigneeId;
 
@@ -1142,7 +1149,7 @@ export class TasksService {
             itemId,
             data.parentId,
           );
-          const assigneeId = await this.resolveAssigneeId(data.assigneeId);
+          const assigneeId = await this.resolveResourceId(data.assigneeId);
           const finalAssigneeId =
             assigneeId !== undefined ? assigneeId : existing.assigneeId;
 

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -4,11 +4,13 @@ import {
   Get,
   Param,
   Patch,
+  Post,
   Query,
   UseGuards,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import {
+  CreateUserAdminDto,
   SearchUsersQueryDto,
   UpdateUserAdminDto,
 } from '@project-workgroup/shared';
@@ -47,6 +49,13 @@ export class UsersController {
   @Get()
   async search(@Query() q: SearchUsersQueryDto) {
     return this.users.search(q);
+  }
+
+  @Post()
+  @UseGuards(RolesGuard)
+  @Roles('admin')
+  async adminCreate(@Body() dto: CreateUserAdminDto) {
+    return this.users.adminCreate(dto);
   }
 
   @Patch(':id')

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,8 +1,21 @@
-import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
-import { SearchUsersQueryDto } from '@project-workgroup/shared';
+import {
+  SearchUsersQueryDto,
+  UpdateUserAdminDto,
+} from '@project-workgroup/shared';
 import { AuthGuard, AuthUser } from '../auth/auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
 import { PrismaService } from '../prisma/prisma.service';
 import { UsersService } from './users.service';
 
@@ -26,6 +39,7 @@ export class UsersController {
       email: full.email,
       displayName: full.displayName,
       role: full.role,
+      status: full.status,
       avatarUrl: full.avatarUrl,
     };
   }
@@ -33,5 +47,12 @@ export class UsersController {
   @Get()
   async search(@Query() q: SearchUsersQueryDto) {
     return this.users.search(q);
+  }
+
+  @Patch(':id')
+  @UseGuards(RolesGuard)
+  @Roles('admin')
+  async adminUpdate(@Param('id') id: string, @Body() dto: UpdateUserAdminDto) {
+    return this.users.adminUpdate(BigInt(id), dto);
   }
 }

--- a/apps/api/src/users/users.module.ts
+++ b/apps/api/src/users/users.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import { AuthModule } from '../auth/auth.module';
+import { FirebaseModule } from '../firebase/firebase.module';
 
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, FirebaseModule],
   controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,14 +1,22 @@
 import {
   BadRequestException,
+  ConflictException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { UpdateUserAdminDto } from '@project-workgroup/shared';
+import {
+  CreateUserAdminDto,
+  UpdateUserAdminDto,
+} from '@project-workgroup/shared';
+import { FirebaseService } from '../firebase/firebase.service';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
 export class UsersService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly firebase: FirebaseService,
+  ) {}
 
   async search(params: { search?: string; limit?: number; cursor?: string }) {
     const take = Math.min(params.limit ?? 25, 100);
@@ -80,5 +88,73 @@ export class UsersService {
       status: updated.status,
       avatarUrl: updated.avatarUrl,
     };
+  }
+
+  async adminCreate(dto: CreateUserAdminDto) {
+    const existing = await this.prisma.user.findUnique({
+      where: { email: dto.email },
+    });
+    if (existing) throw new ConflictException('email already in use');
+
+    let uid: string;
+    try {
+      uid = await this.firebase.createUser({
+        email: dto.email,
+        password: dto.password,
+        displayName: dto.displayName,
+      });
+    } catch (err) {
+      const code = (err as { code?: string })?.code;
+      if (code === 'auth/email-already-exists') {
+        throw new ConflictException('email already in use');
+      }
+      if (code === 'auth/invalid-password' || code === 'auth/weak-password') {
+        throw new BadRequestException('password does not meet requirements');
+      }
+      throw new BadRequestException('could not create firebase user');
+    }
+
+    try {
+      const user = await this.prisma.$transaction(async (tx) => {
+        const created = await tx.user.create({
+          data: {
+            firebaseUid: uid,
+            email: dto.email,
+            displayName: dto.displayName,
+            role: dto.role ?? 'member',
+          },
+        });
+
+        // Invariante: cada user real tiene un resource enlazado (kind='user').
+        await tx.resource.upsert({
+          where: { userId: created.id },
+          update: {
+            name: created.displayName,
+            email: created.email,
+          },
+          create: {
+            name: created.displayName,
+            email: created.email,
+            kind: 'user',
+            userId: created.id,
+          },
+        });
+
+        return created;
+      });
+
+      return {
+        id: user.id.toString(),
+        email: user.email,
+        displayName: user.displayName,
+        role: user.role,
+        status: user.status,
+        avatarUrl: user.avatarUrl,
+      };
+    } catch (err) {
+      // Compensación: evita dejar un usuario huérfano en Firebase si la DB falla.
+      await this.firebase.deleteUser(uid);
+      throw err;
+    }
   }
 }

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,4 +1,9 @@
-import { Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { UpdateUserAdminDto } from '@project-workgroup/shared';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
@@ -36,8 +41,44 @@ export class UsersService {
       email: u.email,
       displayName: u.displayName,
       role: u.role,
+      status: u.status,
       avatarUrl: u.avatarUrl,
     }));
     return { items, nextCursor: hasMore ? items[items.length - 1].id : null };
+  }
+
+  async adminUpdate(id: bigint, dto: UpdateUserAdminDto) {
+    const user = await this.prisma.user.findUnique({ where: { id } });
+    if (!user) throw new NotFoundException('user not found');
+
+    // Impide dejar el sistema sin ningún admin activo.
+    const isActiveAdmin = user.role === 'admin' && user.status === 'active';
+    const losesActiveAdmin =
+      (dto.role !== undefined && dto.role !== 'admin') ||
+      dto.status === 'disabled';
+    if (isActiveAdmin && losesActiveAdmin) {
+      const otherActiveAdmins = await this.prisma.user.count({
+        where: { role: 'admin', status: 'active', id: { not: id } },
+      });
+      if (otherActiveAdmins === 0) {
+        throw new BadRequestException('cannot remove the last active admin');
+      }
+    }
+
+    const updated = await this.prisma.user.update({
+      where: { id },
+      data: {
+        role: dto.role ?? undefined,
+        status: dto.status ?? undefined,
+      },
+    });
+    return {
+      id: updated.id.toString(),
+      email: updated.email,
+      displayName: updated.displayName,
+      role: updated.role,
+      status: updated.status,
+      avatarUrl: updated.avatarUrl,
+    };
   }
 }

--- a/apps/api/src/workload/workload.service.ts
+++ b/apps/api/src/workload/workload.service.ts
@@ -17,7 +17,7 @@ export class WorkloadService {
 
   private toResponse(w: {
     id: bigint;
-    userId: bigint;
+    resourceId: bigint;
     taskId: bigint;
     projectId: bigint;
     date: Date;
@@ -28,7 +28,7 @@ export class WorkloadService {
   }): WorkloadResponse {
     return {
       id: w.id.toString(),
-      userId: w.userId.toString(),
+      resourceId: w.resourceId.toString(),
       taskId: w.taskId.toString(),
       projectId: w.projectId.toString(),
       date: w.date.toISOString().slice(0, 10),
@@ -48,9 +48,14 @@ export class WorkloadService {
     });
     if (!task) throw new NotFoundException('task not found');
 
+    const resource = await this.prisma.resource.findUnique({
+      where: { id: BigInt(dto.resourceId) },
+    });
+    if (!resource) throw new NotFoundException('resource not found');
+
     const workload = await this.prisma.workload.create({
       data: {
-        userId: BigInt(dto.userId),
+        resourceId: BigInt(dto.resourceId),
         taskId: BigInt(dto.taskId),
         projectId,
         date: new Date(dto.date),
@@ -66,7 +71,7 @@ export class WorkloadService {
     q: WorkloadQueryDto,
   ): Promise<WorkloadResponse[]> {
     const where: any = { projectId };
-    if (q.userId) where.userId = BigInt(q.userId);
+    if (q.resourceId) where.resourceId = BigInt(q.resourceId);
     if (q.dateFrom || q.dateTo) {
       where.date = {};
       if (q.dateFrom) where.date.gte = new Date(q.dateFrom);
@@ -74,7 +79,7 @@ export class WorkloadService {
     }
     const rows = await this.prisma.workload.findMany({
       where,
-      orderBy: [{ date: 'asc' }, { userId: 'asc' }],
+      orderBy: [{ date: 'asc' }, { resourceId: 'asc' }],
     });
     return rows.map((w) => this.toResponse(w));
   }

--- a/apps/api/test/resources.e2e-spec.ts
+++ b/apps/api/test/resources.e2e-spec.ts
@@ -1,0 +1,284 @@
+import request from 'supertest';
+import { bootE2E, E2EHandle } from './e2e-setup';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { AuthGuard } from '../src/auth/auth.guard';
+
+interface MockUser {
+  id: bigint;
+  role: 'admin' | 'pm' | 'member';
+  firebaseUid: null;
+  via: 'api_key';
+}
+
+describe('Resources (e2e)', () => {
+  let handle: E2EHandle;
+  let prisma: PrismaService;
+  let ownerId: bigint;
+  let projectId: bigint;
+  let currentUser: MockUser;
+
+  beforeAll(async () => {
+    handle = await bootE2E({
+      overrideGuard: {
+        guard: AuthGuard,
+        value: {
+          canActivate: (ctx: any) => {
+            const req = ctx.switchToHttp().getRequest();
+            req.user = currentUser;
+            return true;
+          },
+        },
+      },
+    });
+    prisma = handle.app.get(PrismaService);
+    const owner = await prisma.user.create({
+      data: {
+        firebaseUid: 'res-owner-uid',
+        email: 'res-owner@example.com',
+        displayName: 'Resources Owner',
+        role: 'admin',
+      },
+    });
+    ownerId = owner.id;
+    const project = await prisma.project.create({
+      data: {
+        name: 'Resources Test Project',
+        startDate: new Date('2026-01-01'),
+        endDate: new Date('2026-12-31'),
+        status: 'planning',
+        ownerId,
+        color: '#abcdef',
+      },
+    });
+    projectId = project.id;
+  }, 180_000);
+
+  afterAll(() => handle.close());
+
+  beforeEach(() => {
+    // Por defecto cada test corre como admin; los tests de gating lo bajan a member.
+    currentUser = {
+      id: ownerId,
+      role: 'admin',
+      firebaseUid: null,
+      via: 'api_key',
+    };
+  });
+
+  // Helper para crear tareas con todos los campos requeridos por el schema (ver workload.e2e-spec.ts).
+  let taskCounter = 0;
+  const createTask = (opts: { assigneeId?: bigint }) => {
+    taskCounter += 1;
+    return prisma.task.create({
+      data: {
+        projectId,
+        name: `Res Task ${taskCounter}`,
+        startDate: new Date('2026-01-01'),
+        endDate: new Date('2026-01-31'),
+        duration: '30',
+        priority: 'medium',
+        status: 'not_started',
+        type: 'task',
+        color: '#ffffff',
+        order: `${1000 + taskCounter}.000000000000000`,
+        assigneeId: opts.assigneeId,
+      },
+    });
+  };
+
+  describe('gating', () => {
+    it('POST /v1/resources → 403 when caller is member', async () => {
+      currentUser = {
+        id: ownerId,
+        role: 'member',
+        firebaseUid: null,
+        via: 'api_key',
+      };
+      const res = await request(handle.app.getHttpServer())
+        .post('/v1/resources')
+        .set('Authorization', 'Bearer fake-token')
+        .send({ name: 'Should Not Create' });
+      expect(res.status).toBe(403);
+    });
+
+    it('POST /v1/resources → 201 when caller is admin and creates a placeholder', async () => {
+      const res = await request(handle.app.getHttpServer())
+        .post('/v1/resources')
+        .set('Authorization', 'Bearer fake-token')
+        .send({ name: 'Admin Created' });
+      expect(res.status).toBe(201);
+      expect(res.body.kind).toBe('placeholder');
+      expect(res.body.name).toBe('Admin Created');
+    });
+  });
+
+  describe('list', () => {
+    it('GET /v1/resources → 200 for any authenticated user (member included)', async () => {
+      currentUser = {
+        id: ownerId,
+        role: 'member',
+        firebaseUid: null,
+        via: 'api_key',
+      };
+      const res = await request(handle.app.getHttpServer())
+        .get('/v1/resources')
+        .set('Authorization', 'Bearer fake-token');
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.items)).toBe(true);
+    });
+  });
+
+  describe('create', () => {
+    it('forces kind=placeholder even though the DTO has no kind field', async () => {
+      // CreateResourceDto no expone "kind"; el service lo fuerza siempre a placeholder
+      // (el forbidNonWhitelisted global rechazaría con 400 si intentáramos colarlo).
+      const res = await request(handle.app.getHttpServer())
+        .post('/v1/resources')
+        .set('Authorization', 'Bearer fake-token')
+        .send({ name: 'Placeholder Only', discipline: 'QA' });
+      expect(res.status).toBe(201);
+      expect(res.body.kind).toBe('placeholder');
+      expect(res.body.discipline).toBe('QA');
+    });
+  });
+
+  describe('update', () => {
+    it('PATCH /v1/resources/:id → 200 updates discipline/status of a placeholder', async () => {
+      const created = await prisma.resource.create({
+        data: { name: 'To Update', kind: 'placeholder' },
+      });
+
+      const res = await request(handle.app.getHttpServer())
+        .patch(`/v1/resources/${created.id}`)
+        .set('Authorization', 'Bearer fake-token')
+        .send({ discipline: 'Backend', status: 'inactive' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.discipline).toBe('Backend');
+      expect(res.body.status).toBe('inactive');
+    });
+  });
+
+  describe('linkToUser', () => {
+    it('merges the user-linked resource into the placeholder and reassigns its work', async () => {
+      const linkUser = await prisma.user.create({
+        data: {
+          firebaseUid: 'res-link-uid',
+          email: 'res-link@example.com',
+          displayName: 'Link User',
+          role: 'member',
+        },
+      });
+      // Simula la invariante de auth.sync: todo user real trae su resource auto-generado.
+      const userResource = await prisma.resource.create({
+        data: { name: 'Link User', kind: 'user', userId: linkUser.id },
+      });
+      const task = await createTask({ assigneeId: userResource.id });
+
+      const placeholder = await prisma.resource.create({
+        data: { name: 'Placeholder To Link', kind: 'placeholder' },
+      });
+
+      const res = await request(handle.app.getHttpServer())
+        .patch(`/v1/resources/${placeholder.id}/link-user`)
+        .set('Authorization', 'Bearer fake-token')
+        .send({ userId: linkUser.id.toString() });
+
+      expect(res.status).toBe(200);
+      expect(res.body.kind).toBe('user');
+      expect(res.body.userId).toBe(linkUser.id.toString());
+
+      const updatedTask = await prisma.task.findUnique({
+        where: { id: task.id },
+      });
+      expect(updatedTask?.assigneeId).toBe(placeholder.id);
+
+      const orphanResource = await prisma.resource.findUnique({
+        where: { id: userResource.id },
+      });
+      expect(orphanResource).toBeNull();
+    });
+
+    it('PATCH .../link-user → 400 when target resource is already kind=user', async () => {
+      const linkUser = await prisma.user.create({
+        data: {
+          firebaseUid: 'res-link-uid-2',
+          email: 'res-link-2@example.com',
+          displayName: 'Link User 2',
+          role: 'member',
+        },
+      });
+      const userResource = await prisma.resource.create({
+        data: { name: 'Link User 2', kind: 'user', userId: linkUser.id },
+      });
+
+      const anotherUser = await prisma.user.create({
+        data: {
+          firebaseUid: 'res-link-uid-3',
+          email: 'res-link-3@example.com',
+          displayName: 'Another User',
+          role: 'member',
+        },
+      });
+
+      const res = await request(handle.app.getHttpServer())
+        .patch(`/v1/resources/${userResource.id}/link-user`)
+        .set('Authorization', 'Bearer fake-token')
+        .send({ userId: anotherUser.id.toString() });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('remove', () => {
+    it('DELETE /v1/resources/:id → 204 for a placeholder without references', async () => {
+      const created = await prisma.resource.create({
+        data: { name: 'To Delete', kind: 'placeholder' },
+      });
+
+      const res = await request(handle.app.getHttpServer())
+        .delete(`/v1/resources/${created.id}`)
+        .set('Authorization', 'Bearer fake-token');
+
+      expect(res.status).toBe(204);
+
+      const removed = await prisma.resource.findUnique({
+        where: { id: created.id },
+      });
+      expect(removed).toBeNull();
+    });
+
+    it('DELETE /v1/resources/:id → 400 for a kind=user resource', async () => {
+      const linkUser = await prisma.user.create({
+        data: {
+          firebaseUid: 'res-del-uid',
+          email: 'res-del@example.com',
+          displayName: 'Del User',
+          role: 'member',
+        },
+      });
+      const userResource = await prisma.resource.create({
+        data: { name: 'Del User', kind: 'user', userId: linkUser.id },
+      });
+
+      const res = await request(handle.app.getHttpServer())
+        .delete(`/v1/resources/${userResource.id}`)
+        .set('Authorization', 'Bearer fake-token');
+
+      expect(res.status).toBe(400);
+    });
+
+    it('DELETE /v1/resources/:id → 409 for a placeholder with an assigned task', async () => {
+      const placeholder = await prisma.resource.create({
+        data: { name: 'Busy Placeholder', kind: 'placeholder' },
+      });
+      await createTask({ assigneeId: placeholder.id });
+
+      const res = await request(handle.app.getHttpServer())
+        .delete(`/v1/resources/${placeholder.id}`)
+        .set('Authorization', 'Bearer fake-token');
+
+      expect(res.status).toBe(409);
+    });
+  });
+});

--- a/apps/api/test/workload.e2e-spec.ts
+++ b/apps/api/test/workload.e2e-spec.ts
@@ -17,6 +17,7 @@ describe('Workload (e2e)', () => {
   let outsiderId: bigint;
   let projectId: bigint;
   let taskId: bigint;
+  let resourceId: bigint;
   let currentUser: MockUser;
 
   beforeAll(async () => {
@@ -42,6 +43,11 @@ describe('Workload (e2e)', () => {
       },
     });
     ownerId = owner.id;
+    // El workload apunta a un resource, no a un user: creamos el resource enlazado del owner.
+    const resource = await prisma.resource.create({
+      data: { name: 'WL Owner', kind: 'user', userId: ownerId },
+    });
+    resourceId = resource.id;
     const outsider = await prisma.user.create({
       data: {
         firebaseUid: 'wl-outsider-uid',
@@ -101,7 +107,7 @@ describe('Workload (e2e)', () => {
       .post(`/v1/projects/${projectId}/workload`)
       .set('Authorization', 'Bearer fake-token')
       .send({
-        userId: ownerId.toString(),
+        resourceId: resourceId.toString(),
         taskId: taskId.toString(),
         date: '2026-01-15',
         allocatedHours: '8',
@@ -116,7 +122,7 @@ describe('Workload (e2e)', () => {
       .post(`/v1/projects/${projectId}/workload`)
       .set('Authorization', 'Bearer fake-token')
       .send({
-        userId: ownerId.toString(),
+        resourceId: resourceId.toString(),
         taskId: taskId.toString(),
         date: '2026-02-10',
         allocatedHours: '4',
@@ -135,7 +141,7 @@ describe('Workload (e2e)', () => {
   it('DELETE /v1/workload/:id → 403 when caller is not a project member', async () => {
     const created = await prisma.workload.create({
       data: {
-        userId: ownerId,
+        resourceId: resourceId,
         taskId,
         projectId,
         date: new Date('2026-03-01'),
@@ -164,7 +170,7 @@ describe('Workload (e2e)', () => {
   it('DELETE /v1/workload/:id → 204 when caller is project owner', async () => {
     const created = await prisma.workload.create({
       data: {
-        userId: ownerId,
+        resourceId: resourceId,
         taskId,
         projectId,
         date: new Date('2026-04-01'),

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@project-workgroup/web",
   "private": true,
-  "version": "2.1.0",
+  "version": "3.0.0",
   "type": "module",
   "engines": {
     "node": ">=20.0.0"

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-d
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import AppLayout from './components/Layout/AppLayout';
 import ProtectedRoute from './components/ProtectedRoute';
+import AdminRoute from './components/AdminRoute';
 import Login from './pages/Login';
 import Dashboard from './pages/Dashboard';
 import ProjectView from './pages/ProjectView';
@@ -9,6 +10,8 @@ import AccountApiKeys from './pages/AccountApiKeys';
 import CalendarSettingsPage from './pages/CalendarSettingsPage';
 import ProjectSettingsPage from './pages/ProjectSettingsPage';
 import SettingsPage from './pages/SettingsPage';
+import AdminUsers from './pages/AdminUsers';
+import AdminResources from './pages/AdminResources';
 
 const LoginWrapper = () => {
   const { user, loading } = useAuth();
@@ -110,6 +113,27 @@ function App() {
                     <CalendarSettingsPage />
                   </AppLayout>
                 </ProtectedRoute>
+              }
+            />
+
+            <Route
+              path="/admin/users"
+              element={
+                <AdminRoute>
+                  <AppLayout>
+                    <AdminUsers />
+                  </AppLayout>
+                </AdminRoute>
+              }
+            />
+            <Route
+              path="/admin/resources"
+              element={
+                <AdminRoute>
+                  <AppLayout>
+                    <AdminResources />
+                  </AppLayout>
+                </AdminRoute>
               }
             />
 

--- a/apps/web/src/components/AdminRoute.tsx
+++ b/apps/web/src/components/AdminRoute.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import ProtectedRoute from './ProtectedRoute';
+import { useUserRole } from '../hooks/useUserRole';
+
+interface AdminRouteProps {
+  children: React.ReactNode;
+}
+
+// Gate interno: asume que ya pasó ProtectedRoute (usuario autenticado)
+const AdminGate: React.FC<AdminRouteProps> = ({ children }) => {
+  const { isAdmin, loading } = useUserRole();
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary-500"></div>
+      </div>
+    );
+  }
+
+  if (!isAdmin) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+const AdminRoute: React.FC<AdminRouteProps> = ({ children }) => (
+  <ProtectedRoute>
+    <AdminGate>{children}</AdminGate>
+  </ProtectedRoute>
+);
+
+export default AdminRoute;

--- a/apps/web/src/components/GanttChart.tsx
+++ b/apps/web/src/components/GanttChart.tsx
@@ -15,6 +15,7 @@ import type {
   ToolbarItem,
 } from 'wx-react-gantt';
 import type { Task, TaskLink } from '../types/domain';
+import type { AssigneeOption } from './TasksView/NewTaskRow';
 import type { WorkingCalendarResponse } from '@project-workgroup/shared';
 import {
   GanttDataProvider,
@@ -47,6 +48,7 @@ interface GanttChartProps {
   onLinksChanged?: (payload: GanttLinkChangePayload) => void;
   calendar?: WorkingCalendarResponse | null;
   onSelectTask?: (taskId: string) => void;
+  assignees?: AssigneeOption[];
 }
 
 const GanttChart: React.FC<GanttChartProps> = ({
@@ -61,6 +63,7 @@ const GanttChart: React.FC<GanttChartProps> = ({
   onLinksChanged,
   calendar: calendarFromProps,
   onSelectTask,
+  assignees,
 }) => {
   const internalApiRef = useRef<GanttApi | null>(null);
   const apiRef = externalApiRef ?? internalApiRef;
@@ -243,12 +246,50 @@ const GanttChart: React.FC<GanttChartProps> = ({
     return [{ start: today, text: 'Hoy', css: 'current-day-marker' }];
   }, []);
 
+  const assigneesById = React.useMemo(() => {
+    const map = new Map<string, AssigneeOption>();
+    (assignees ?? []).forEach((a) => map.set(a.id, a));
+    return map;
+  }, [assignees]);
+
   const columns: GanttColumn[] = React.useMemo(() => {
     const STATUS_LABEL: Record<string, string> = {
       'not-started': 'No iniciada',
       'in-progress': 'En curso',
       completed: 'Completada',
       blocked: 'Bloqueada',
+    };
+
+    // Avatar (imagen si hay) o iniciales en un círculo, con tooltip nativo (title) =
+    // nombre + especialidad. Estilos inline con tokens para no depender de un CSS aparte.
+    const assigneeCell = (
+      _v: unknown,
+      task: GanttTask & { assigneeId?: string | null },
+    ): string => {
+      const a = task.assigneeId ? assigneesById.get(String(task.assigneeId)) : undefined;
+      if (!a) return '<span style="color:var(--ink-3)">—</span>';
+      const esc = (s: string) =>
+        String(s)
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;');
+      const tip = esc(a.discipline ? `${a.displayName} — ${a.discipline}` : a.displayName);
+      const base =
+        'display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;border-radius:999px;font:600 10px/1 var(--font-sans);overflow:hidden;vertical-align:middle';
+      if (a.avatar) {
+        return `<span title="${tip}" style="${base}"><img src="${esc(a.avatar)}" alt="" style="width:100%;height:100%;object-fit:cover" /></span>`;
+      }
+      const initials = esc(
+        a.displayName
+          .trim()
+          .split(/\s+/)
+          .slice(0, 2)
+          .map((w) => w[0] ?? '')
+          .join('')
+          .toUpperCase() || '?',
+      );
+      return `<span title="${tip}" style="${base};background:var(--p-100);color:var(--p-700)">${initials}</span>`;
     };
 
     return [
@@ -303,6 +344,13 @@ const GanttChart: React.FC<GanttChartProps> = ({
         },
       },
       {
+        id: 'assignee',
+        header: 'Responsable',
+        align: 'center',
+        width: 96,
+        template: assigneeCell,
+      },
+      {
         id: 'action',
         header: 'Acciones',
         align: 'center',
@@ -319,7 +367,7 @@ const GanttChart: React.FC<GanttChartProps> = ({
         },
       },
     ];
-  }, []);
+  }, [assigneesById]);
 
   const handleAddTaskFromToolbar = async () => {
     try {

--- a/apps/web/src/components/GanttChart.tsx
+++ b/apps/web/src/components/GanttChart.tsx
@@ -28,6 +28,7 @@ import { createHighlightTime } from '../services/workingCalendarMarkers';
 import { LocaleProvider } from './LocaleProvider';
 import { setupAutoLocalization } from '../utils/ganttLocalizer';
 import { applyBarTooltips } from '../utils/ganttBarTooltips';
+import { applyAssigneeCells, type AssigneeCellInfo } from '../utils/ganttAssigneeCells';
 import { GanttDragTooltip, type DragTooltipContext } from '../utils/ganttDragTooltip';
 import { computeStructuralKey } from '../utils/ganttStructuralKey';
 import { GanttTimeline } from './GanttTimeline';
@@ -247,7 +248,7 @@ const GanttChart: React.FC<GanttChartProps> = ({
   }, []);
 
   const assigneesById = React.useMemo(() => {
-    const map = new Map<string, AssigneeOption>();
+    const map = new Map<string, AssigneeCellInfo>();
     (assignees ?? []).forEach((a) => map.set(a.id, a));
     return map;
   }, [assignees]);
@@ -258,38 +259,6 @@ const GanttChart: React.FC<GanttChartProps> = ({
       'in-progress': 'En curso',
       completed: 'Completada',
       blocked: 'Bloqueada',
-    };
-
-    // Avatar (imagen si hay) o iniciales en un círculo, con tooltip nativo (title) =
-    // nombre + especialidad. Estilos inline con tokens para no depender de un CSS aparte.
-    const assigneeCell = (
-      _v: unknown,
-      task: GanttTask & { assigneeId?: string | null },
-    ): string => {
-      const a = task.assigneeId ? assigneesById.get(String(task.assigneeId)) : undefined;
-      if (!a) return '<span style="color:var(--ink-3)">—</span>';
-      const esc = (s: string) =>
-        String(s)
-          .replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-          .replace(/"/g, '&quot;');
-      const tip = esc(a.discipline ? `${a.displayName} — ${a.discipline}` : a.displayName);
-      const base =
-        'display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;border-radius:999px;font:600 10px/1 var(--font-sans);overflow:hidden;vertical-align:middle';
-      if (a.avatar) {
-        return `<span title="${tip}" style="${base}"><img src="${esc(a.avatar)}" alt="" style="width:100%;height:100%;object-fit:cover" /></span>`;
-      }
-      const initials = esc(
-        a.displayName
-          .trim()
-          .split(/\s+/)
-          .slice(0, 2)
-          .map((w) => w[0] ?? '')
-          .join('')
-          .toUpperCase() || '?',
-      );
-      return `<span title="${tip}" style="${base};background:var(--p-100);color:var(--p-700)">${initials}</span>`;
     };
 
     return [
@@ -348,7 +317,9 @@ const GanttChart: React.FC<GanttChartProps> = ({
         header: 'Responsable',
         align: 'center',
         width: 96,
-        template: assigneeCell,
+        // El contenido (avatar) se inyecta por DOM en un effect: el grid escapa el HTML
+        // del template. Se deja vacío para no mostrar texto crudo.
+        template: () => '',
       },
       {
         id: 'action',
@@ -367,7 +338,7 @@ const GanttChart: React.FC<GanttChartProps> = ({
         },
       },
     ];
-  }, [assigneesById]);
+  }, []);
 
   const handleAddTaskFromToolbar = async () => {
     try {
@@ -545,6 +516,39 @@ const GanttChart: React.FC<GanttChartProps> = ({
       observer.disconnect();
     };
   }, [apiRef, dataProvider]);
+
+  // Inyecta el avatar del responsable en las celdas de la columna "assignee": el grid
+  // renderiza el template como texto, así que se hace por DOM (patrón de applyBarTooltips).
+  // El MutationObserver re-aplica al re-renderizar el grid (scroll/virtualización/updates);
+  // el guard idempotente del util evita bucles. Re-corre al cambiar tareas o asignados.
+  useEffect(() => {
+    const root = containerRef.current;
+    if (!root) return;
+    const THROTTLE_MS = 150;
+    let scheduled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    const apply = () => {
+      scheduled = false;
+      applyAssigneeCells(apiRef.current, root, assigneesById);
+    };
+    const schedule = () => {
+      if (scheduled) return;
+      scheduled = true;
+      timeoutId = setTimeout(apply, THROTTLE_MS);
+    };
+
+    schedule();
+    const grid = root.querySelector('.wx-grid') ?? root;
+    const observer = new MutationObserver(schedule);
+    observer.observe(grid, { childList: true, subtree: true });
+
+    return () => {
+      scheduled = false;
+      if (timeoutId !== null) clearTimeout(timeoutId);
+      observer.disconnect();
+    };
+  }, [apiRef, assigneesById, tasks, dataProvider, toolbarApi]);
 
   // Tooltip en vivo durante el arrastre: se monta cuando el contenedor del Gantt existe.
   useEffect(() => {

--- a/apps/web/src/components/MemberManagement.tsx
+++ b/apps/web/src/components/MemberManagement.tsx
@@ -1,25 +1,43 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Search, Loader2, X, Users, AlertTriangle } from 'lucide-react';
 import { useMembers } from '../hooks/useMembers';
+import type { ProjectRole } from '@project-workgroup/shared';
 
 interface MemberManagementProps {
   projectId: string;
+  isOwner?: boolean;
   onClose?: () => void;
 }
 
-const ROLE_VARIANT: Record<string, 'err' | 'info' | 'ok' | 'outline'> = {
+// Rol global del usuario (candidatos de búsqueda vienen de /v1/users con UserRole, no ProjectRole)
+const USER_ROLE_VARIANT: Record<string, 'err' | 'info' | 'ok' | 'outline'> = {
   admin: 'err',
   pm: 'info',
   member: 'ok',
 };
 
-const ROLE_LABEL: Record<string, string> = {
+const USER_ROLE_LABEL: Record<string, string> = {
   admin: 'Admin',
   pm: 'PM',
   member: 'Miembro',
 };
 
-const MemberManagement: React.FC<MemberManagementProps> = ({ projectId, onClose }) => {
+// Rol del miembro dentro del proyecto (ProjectRole real del backend)
+const ROLE_VARIANT: Record<ProjectRole, 'err' | 'info' | 'ok' | 'outline'> = {
+  manager: 'err',
+  contributor: 'info',
+  viewer: 'ok',
+};
+
+const ROLE_LABEL: Record<ProjectRole, string> = {
+  manager: 'Gestor',
+  contributor: 'Colaborador',
+  viewer: 'Visor',
+};
+
+const ROLE_OPTIONS: ProjectRole[] = ['manager', 'contributor', 'viewer'];
+
+const MemberManagement: React.FC<MemberManagementProps> = ({ projectId, isOwner = false, onClose }) => {
   const {
     members,
     searchResults,
@@ -30,13 +48,15 @@ const MemberManagement: React.FC<MemberManagementProps> = ({ projectId, onClose 
     searchUsers,
     addMember,
     removeMember,
+    updateMemberRole,
     clearSearch,
-  } = useMembers(projectId);
+  } = useMembers(projectId, isOwner);
 
   const [searchQuery, setSearchQuery] = useState('');
   const [showSearchResults, setShowSearchResults] = useState(false);
   const [isAddingMember, setIsAddingMember] = useState<string | null>(null);
   const [isRemovingMember, setIsRemovingMember] = useState<string | null>(null);
+  const [isChangingRole, setIsChangingRole] = useState<string | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -80,6 +100,18 @@ const MemberManagement: React.FC<MemberManagementProps> = ({ projectId, onClose 
       alert(err instanceof Error ? err.message : 'Error al quitar miembro');
     } finally {
       setIsRemovingMember(null);
+    }
+  };
+
+  const handleRoleChange = async (userId: string, projectRole: ProjectRole) => {
+    setIsChangingRole(userId);
+    try {
+      await updateMemberRole(userId, projectRole);
+    } catch (err) {
+      console.error('Error changing member role:', err);
+      alert(err instanceof Error ? err.message : 'Error al cambiar el rol');
+    } finally {
+      setIsChangingRole(null);
     }
   };
 
@@ -180,7 +212,7 @@ const MemberManagement: React.FC<MemberManagementProps> = ({ projectId, onClose 
                         {u.email}
                       </p>
                     </div>
-                    <span className={`badge ${ROLE_VARIANT[u.role] ?? 'outline'}`}>{ROLE_LABEL[u.role] ?? u.role}</span>
+                    <span className={`badge ${USER_ROLE_VARIANT[u.role] ?? 'outline'}`}>{USER_ROLE_LABEL[u.role] ?? u.role}</span>
                   </div>
                   <button
                     onClick={() => handleAddMember(u.id)}
@@ -251,7 +283,22 @@ const MemberManagement: React.FC<MemberManagementProps> = ({ projectId, onClose 
                     {m.email}
                   </p>
                 </div>
-                <span className={`badge ${ROLE_VARIANT[m.role] ?? 'outline'}`}>{ROLE_LABEL[m.role] ?? m.role}</span>
+                {permissions?.canChangeRoles ? (
+                  <select
+                    className="select"
+                    value={m.role}
+                    disabled={isChangingRole === m.userId}
+                    onChange={(e) => handleRoleChange(m.userId, e.target.value as ProjectRole)}
+                  >
+                    {ROLE_OPTIONS.map((role) => (
+                      <option key={role} value={role}>
+                        {ROLE_LABEL[role]}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <span className={`badge ${ROLE_VARIANT[m.role] ?? 'outline'}`}>{ROLE_LABEL[m.role] ?? m.role}</span>
+                )}
               </div>
 
               {permissions?.canRemoveMembers && (

--- a/apps/web/src/components/MemberModal.tsx
+++ b/apps/web/src/components/MemberModal.tsx
@@ -7,9 +7,10 @@ interface MemberModalProps {
   onClose: () => void;
   projectId: string;
   projectName: string;
+  isOwner?: boolean;
 }
 
-const MemberModal: React.FC<MemberModalProps> = ({ isOpen, onClose, projectId, projectName }) => {
+const MemberModal: React.FC<MemberModalProps> = ({ isOpen, onClose, projectId, projectName, isOwner = false }) => {
   if (!isOpen) return null;
 
   return (
@@ -34,7 +35,7 @@ const MemberModal: React.FC<MemberModalProps> = ({ isOpen, onClose, projectId, p
         </div>
 
         <div className="modal-body">
-          <MemberManagement projectId={projectId} />
+          <MemberManagement projectId={projectId} isOwner={isOwner} />
         </div>
       </div>
     </div>

--- a/apps/web/src/components/ProjectList.tsx
+++ b/apps/web/src/components/ProjectList.tsx
@@ -204,6 +204,7 @@ const ProjectList: React.FC<ProjectListProps> = ({
   onDeleteProject,
   onLoadMore,
 }) => {
+  const { user } = useAuth();
   const { isAdmin, isPM } = useUserRole();
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [memberModalOpen, setMemberModalOpen] = useState(false);
@@ -382,6 +383,7 @@ const ProjectList: React.FC<ProjectListProps> = ({
           onClose={closeMemberModal}
           projectId={selectedProject.id}
           projectName={selectedProject.name}
+          isOwner={user?.uid === selectedProject.ownerId}
         />
       )}
     </div>

--- a/apps/web/src/components/ResourceModal.tsx
+++ b/apps/web/src/components/ResourceModal.tsx
@@ -1,0 +1,160 @@
+import React, { useEffect, useState } from 'react';
+import { X, Loader2 } from 'lucide-react';
+
+interface ResourceModalInitial {
+  name: string;
+  email: string | null;
+  discipline: string | null;
+}
+
+interface ResourceModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (data: { name: string; email?: string; discipline?: string }) => Promise<void>;
+  initial?: ResourceModalInitial;
+  // Recursos kind === 'user' tienen name/email gestionados por el usuario vinculado; solo la disciplina es editable
+  identityReadOnly?: boolean;
+}
+
+const ResourceModal: React.FC<ResourceModalProps> = ({ open, onClose, onSubmit, initial, identityReadOnly }) => {
+  const [loading, setLoading] = useState(false);
+  const [formData, setFormData] = useState({ name: '', email: '', discipline: '' });
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (initial) {
+      setFormData({
+        name: initial.name,
+        email: initial.email ?? '',
+        discipline: initial.discipline ?? '',
+      });
+    } else {
+      setFormData({ name: '', email: '', discipline: '' });
+    }
+    setErrors({});
+  }, [initial, open]);
+
+  const validateForm = (): boolean => {
+    const newErrors: Record<string, string> = {};
+    if (!formData.name.trim()) newErrors.name = 'El nombre es requerido';
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleInputChange = (field: 'name' | 'email' | 'discipline', value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    if (errors[field]) setErrors((prev) => ({ ...prev, [field]: '' }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validateForm()) return;
+    setLoading(true);
+    try {
+      await onSubmit({
+        name: formData.name.trim(),
+        email: formData.email.trim() || undefined,
+        discipline: formData.discipline.trim() || undefined,
+      });
+      onClose();
+    } catch (error) {
+      console.error('Error submitting resource:', error);
+      setErrors({ submit: error instanceof Error ? error.message : 'Error al guardar el recurso. Inténtalo de nuevo.' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!open) return null;
+
+  const inputClass = (field: string) => `input ${errors[field] ? 'border-err-line' : ''}`;
+  const errorStyle: React.CSSProperties = {
+    color: 'var(--err-fg)',
+    font: '400 var(--t-caption)/1.3 var(--font-sans)',
+    margin: '4px 0 0',
+  };
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-head">
+          <h2 className="ttl">{initial ? 'Editar recurso' : 'Nuevo recurso'}</h2>
+          <button onClick={onClose} className="btn btn-ghost btn-icon btn-sm" disabled={loading} aria-label="Cerrar">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="contents">
+          <div className="modal-body space-y-4">
+            <div className="field">
+              <label htmlFor="name" className="field-label">Nombre *</label>
+              <input
+                type="text"
+                id="name"
+                value={formData.name}
+                onChange={(e) => handleInputChange('name', e.target.value)}
+                className={inputClass('name')}
+                placeholder="Ej: Juan Pérez"
+                disabled={loading || identityReadOnly}
+              />
+              {errors.name && <p style={errorStyle}>{errors.name}</p>}
+            </div>
+
+            <div className="field">
+              <label htmlFor="email" className="field-label">Email</label>
+              <input
+                type="email"
+                id="email"
+                value={formData.email}
+                onChange={(e) => handleInputChange('email', e.target.value)}
+                className="input"
+                placeholder="nombre@empresa.com"
+                disabled={loading || identityReadOnly}
+              />
+            </div>
+
+            <div className="field">
+              <label htmlFor="discipline" className="field-label">Disciplina</label>
+              <input
+                type="text"
+                id="discipline"
+                value={formData.discipline}
+                onChange={(e) => handleInputChange('discipline', e.target.value)}
+                className="input"
+                placeholder="Ej: Frontend, QA, Diseño…"
+                disabled={loading}
+              />
+            </div>
+
+            {errors.submit && (
+              <div
+                style={{
+                  background: 'var(--err-bg)',
+                  border: '1px solid var(--err-line)',
+                  color: 'var(--err-fg)',
+                  borderRadius: 'var(--r-md)',
+                  padding: 'var(--s-3) var(--s-4)',
+                  font: '400 var(--t-small)/var(--lh-small) var(--font-sans)',
+                }}
+              >
+                {errors.submit}
+              </div>
+            )}
+          </div>
+
+          <div className="modal-foot">
+            <button type="button" onClick={onClose} className="btn btn-secondary" disabled={loading}>
+              Cancelar
+            </button>
+            <button type="submit" className="btn btn-primary" disabled={loading}>
+              {loading && <Loader2 className="w-4 h-4 animate-spin" />}
+              Guardar
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ResourceModal;

--- a/apps/web/src/components/TaskSidebar/TaskSidebar.tsx
+++ b/apps/web/src/components/TaskSidebar/TaskSidebar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { X, Save } from 'lucide-react';
 import type { Task, TaskStatus, TaskPriority, TaskType } from '../../types/domain';
+import type { AssigneeOption } from '../TasksView/NewTaskRow';
 import { useProjectSettings } from '../../contexts/ProjectSettingsContext';
 import './taskSidebar.css';
 
@@ -14,6 +15,7 @@ interface UpdatePatch {
   progress?: number;
   startDate?: string;
   endDate?: string;
+  assigneeId?: string | null;
 }
 
 interface Props {
@@ -21,6 +23,7 @@ interface Props {
   open: boolean;
   onClose: () => void;
   onSave: (taskId: string, patch: UpdatePatch, expectedVersion?: number) => Promise<void>;
+  assignees?: AssigneeOption[];
 }
 
 const STATUS_OPTIONS: { value: TaskStatus; label: string }[] = [
@@ -76,7 +79,7 @@ const inputToIso = (value: string): string | null => {
   return new Date(Date.UTC(Number(y), Number(mo) - 1, Number(d), 0, 0, 0)).toISOString();
 };
 
-const TaskSidebar: React.FC<Props> = ({ task, open, onClose, onSave }) => {
+const TaskSidebar: React.FC<Props> = ({ task, open, onClose, onSave, assignees }) => {
   const { isDays } = useProjectSettings();
   const [name, setName] = React.useState('');
   const [description, setDescription] = React.useState('');
@@ -87,6 +90,7 @@ const TaskSidebar: React.FC<Props> = ({ task, open, onClose, onSave }) => {
   const [progress, setProgress] = React.useState('0');
   const [startDate, setStartDate] = React.useState('');
   const [endDate, setEndDate] = React.useState('');
+  const [assigneeId, setAssigneeId] = React.useState<string>('');
   const [saving, setSaving] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
 
@@ -101,6 +105,7 @@ const TaskSidebar: React.FC<Props> = ({ task, open, onClose, onSave }) => {
     setProgress(String(task.progress ?? 0));
     setStartDate(isDays ? isoToDateInput(task.startDate) : isoToDateTimeInput(task.startDate));
     setEndDate(isDays ? isoToDateInput(task.endDate) : isoToDateTimeInput(task.endDate));
+    setAssigneeId(task.assigneeId ?? '');
     setError(null);
   }, [task, isDays]);
 
@@ -126,6 +131,7 @@ const TaskSidebar: React.FC<Props> = ({ task, open, onClose, onSave }) => {
     if (startIso && startIso !== new Date(task.startDate).toISOString()) patch.startDate = startIso;
     const endIso = inputToIso(endDate);
     if (endIso && endIso !== new Date(task.endDate).toISOString()) patch.endDate = endIso;
+    if ((assigneeId || null) !== (task.assigneeId ?? null)) patch.assigneeId = assigneeId || null;
     if (Object.keys(patch).length === 0) {
       onClose();
       return;
@@ -206,6 +212,16 @@ const TaskSidebar: React.FC<Props> = ({ task, open, onClose, onSave }) => {
             <select className="ts-input" value={taskType} onChange={(e) => setTaskType(e.target.value as TaskType)}>
               {TYPE_OPTIONS.map((o) => (
                 <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </label>
+
+          <label className="ts-field">
+            <span className="ts-label">Responsable</span>
+            <select className="ts-input" value={assigneeId} onChange={(e) => setAssigneeId(e.target.value)}>
+              <option value="">Sin asignar</option>
+              {(assignees ?? []).map((a) => (
+                <option key={a.id} value={a.id}>{a.displayName}{a.discipline ? ` · ${a.discipline}` : ''}</option>
               ))}
             </select>
           </label>

--- a/apps/web/src/components/TasksView/NewTaskRow.tsx
+++ b/apps/web/src/components/TasksView/NewTaskRow.tsx
@@ -15,6 +15,7 @@ export interface AssigneeOption {
   id: string;
   displayName: string;
   avatar?: string;
+  discipline?: string;
 }
 
 interface Props {

--- a/apps/web/src/components/TasksView/TaskListView.tsx
+++ b/apps/web/src/components/TasksView/TaskListView.tsx
@@ -25,6 +25,7 @@ type InlinePatch = {
   progress?: number;
   startDate?: string;
   endDate?: string;
+  assigneeId?: string | null;
 };
 
 const STATUS_LABEL: Record<TaskStatus, string> = {
@@ -127,6 +128,16 @@ const formatHours = (n: number | undefined): string => {
   return `${v.toLocaleString('es', { maximumFractionDigits: 1 })} h`;
 };
 
+// Iniciales (1-2 letras) a partir del nombre completo, para el avatar sin imagen
+const getInitials = (displayName: string): string =>
+  displayName
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((w) => w[0] ?? '')
+    .join('')
+    .toUpperCase() || '?';
+
 interface TreeNode {
   task: Task;
   depth: number;
@@ -180,6 +191,12 @@ const TaskListView: React.FC<Props> = ({ tasks, onCreate, onUpdate, onSelectTask
   const [dateEdit, setDateEdit] = useState<DateEdit>(null);
   const [savingIds, setSavingIds] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
+
+  const assigneesById = useMemo(() => {
+    const m = new Map<string, AssigneeOption>();
+    (assignees ?? []).forEach((a) => m.set(a.id, a));
+    return m;
+  }, [assignees]);
 
   const ordered = useMemo(() => {
     if (sortKey === 'order') return buildOrderedTree(tasks);
@@ -356,6 +373,9 @@ const TaskListView: React.FC<Props> = ({ tasks, onCreate, onUpdate, onSelectTask
               <th className="tv-th tv-th-sortable" onClick={() => toggleSort('name')}>
                 Tarea <SortArrow active={sortKey === 'name'} dir={sortDir} />
               </th>
+              <th className="tv-th tv-th--center" style={{ width: 120 }}>
+                Responsable
+              </th>
               <th className="tv-th tv-th--center tv-th-sortable" onClick={() => toggleSort('priority')} style={{ width: 64 }}>
                 Prio <SortArrow active={sortKey === 'priority'} dir={sortDir} />
               </th>
@@ -380,6 +400,10 @@ const TaskListView: React.FC<Props> = ({ tasks, onCreate, onUpdate, onSelectTask
             {ordered.map(({ task, depth }) => {
               const typeMark = TYPE_MARK[task.type];
               const isSaving = savingIds.has(task.id);
+              const assignee = task.assigneeId ? assigneesById.get(task.assigneeId) : undefined;
+              const assigneeTitle = assignee
+                ? (assignee.discipline ? `${assignee.displayName} — ${assignee.discipline}` : assignee.displayName)
+                : 'Sin asignar';
               return (
                 <tr
                   key={task.id}
@@ -430,6 +454,52 @@ const TaskListView: React.FC<Props> = ({ tasks, onCreate, onUpdate, onSelectTask
                       )}
                       {typeMark && (
                         <span className="tv-type-mark" data-type={task.type}>{typeMark}</span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="tv-td tv-td--center">
+                    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
+                      {assignee?.avatar ? (
+                        <img
+                          src={assignee.avatar}
+                          alt=""
+                          title={assigneeTitle}
+                          style={{ width: 24, height: 24, borderRadius: 999, objectFit: 'cover' }}
+                        />
+                      ) : assignee ? (
+                        <span
+                          title={assigneeTitle}
+                          style={{
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            width: 24,
+                            height: 24,
+                            borderRadius: 999,
+                            fontSize: 10,
+                            fontWeight: 600,
+                            background: 'var(--p-100)',
+                            color: 'var(--p-700)',
+                          }}
+                        >
+                          {getInitials(assignee.displayName)}
+                        </span>
+                      ) : (
+                        <span title="Sin asignar" style={{ color: 'var(--ink-3)' }}>—</span>
+                      )}
+                      {onUpdate && assignees && assignees.length > 0 && (
+                        <select
+                          className="tv-create-mini"
+                          aria-label={`Reasignar responsable de ${task.name}`}
+                          value={task.assigneeId ?? ''}
+                          onChange={(e) => applyPatch(task, { assigneeId: e.target.value || null })}
+                          style={{ width: 'auto', minWidth: 96 }}
+                        >
+                          <option value="">Sin asignar</option>
+                          {assignees.map((a) => (
+                            <option key={a.id} value={a.id}>{a.displayName}</option>
+                          ))}
+                        </select>
                       )}
                     </div>
                   </td>

--- a/apps/web/src/components/TasksView/TasksView.tsx
+++ b/apps/web/src/components/TasksView/TasksView.tsx
@@ -35,6 +35,7 @@ interface Props {
       progress?: number;
       startDate?: string;
       endDate?: string;
+      assigneeId?: string | null;
     },
     expectedVersion?: number,
   ) => Promise<void>;
@@ -135,6 +136,7 @@ const TasksView: React.FC<Props> = ({
               onLinksChanged={onLinksChanged}
               calendar={calendar}
               onSelectTask={handleSelectTask}
+              assignees={assignees}
             />
           </div>
         ) : (
@@ -153,6 +155,7 @@ const TasksView: React.FC<Props> = ({
         task={selectedTask}
         open={selectedTask !== null}
         onClose={handleCloseSidebar}
+        assignees={assignees}
         onSave={async (taskId, patch, expectedVersion) => {
           if (onUpdateTask) await onUpdateTask(taskId, patch, expectedVersion);
         }}

--- a/apps/web/src/hooks/useMembers.ts
+++ b/apps/web/src/hooks/useMembers.ts
@@ -1,12 +1,14 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { MemberService } from '../services/memberService';
 import { useAuth } from '../contexts/AuthContext';
+import { useUserRole } from './useUserRole';
 import type {
   ProjectMember,
   UserSearchResult,
   MemberSearchFilters,
   MemberManagementPermissions
 } from '../types/domain';
+import type { ProjectRole } from '@project-workgroup/shared';
 
 interface UseMembersState {
   members: ProjectMember[];
@@ -22,14 +24,16 @@ interface UseMembersActions {
   searchUsers: (filters: MemberSearchFilters) => Promise<void>;
   addMember: (userId: string) => Promise<void>;
   removeMember: (userId: string) => Promise<void>;
+  updateMemberRole: (userId: string, projectRole: ProjectRole) => Promise<void>;
   clearSearch: () => void;
   refreshPermissions: () => Promise<void>;
 }
 
 interface UseMembersReturn extends UseMembersState, UseMembersActions {}
 
-export function useMembers(projectId: string | null): UseMembersReturn {
+export function useMembers(projectId: string | null, isOwner: boolean = false): UseMembersReturn {
   const { user } = useAuth();
+  const { isAdmin } = useUserRole();
   const [state, setState] = useState<UseMembersState>({
     members: [],
     searchResults: [],
@@ -122,7 +126,7 @@ export function useMembers(projectId: string | null): UseMembersReturn {
 
     try {
       await MemberService.removeMember(projectId, userId, user.uid);
-      
+
       // Recargar miembros después de quitar
       await loadMembers();
     } catch (error) {
@@ -131,43 +135,52 @@ export function useMembers(projectId: string | null): UseMembersReturn {
     }
   }, [projectId, user, loadMembers]);
 
+  // Cambiar el rol de un miembro
+  const updateMemberRole = useCallback(async (userId: string, projectRole: ProjectRole): Promise<void> => {
+    if (!projectId) {
+      throw new Error('Proyecto no disponible');
+    }
+
+    try {
+      await MemberService.updateMemberRole(projectId, userId, projectRole);
+
+      // Recargar miembros después de cambiar el rol
+      await loadMembers();
+    } catch (error) {
+      console.error('Error updating member role:', error);
+      throw error;
+    }
+  }, [projectId, loadMembers]);
+
   // Limpiar resultados de búsqueda
   const clearSearch = useCallback((): void => {
     setState(prev => ({ ...prev, searchResults: [] }));
   }, []);
 
-  // Refrescar permisos
-  const refreshPermissions = useCallback(async (): Promise<void> => {
-    if (!projectId || !user) {
-      setState(prev => ({ ...prev, permissions: null }));
-      return;
-    }
+  // Rol propio dentro del proyecto: el uid de Firebase no mapea directo al userId del backend,
+  // así que se busca por email (sí disponible en ambos lados) entre los miembros cargados.
+  const myRole = useMemo<ProjectRole | null>(() => {
+    return state.members.find(m => m.email === user?.email)?.role ?? null;
+  }, [state.members, user]);
 
-    try {
-      const permissions = await MemberService.getMemberManagementPermissions(projectId, user.uid);
-      setState(prev => ({ ...prev, permissions }));
-    } catch (error) {
-      console.error('Error loading permissions:', error);
-      setState(prev => ({
-        ...prev,
-        permissions: {
-          canAddMembers: false,
-          canRemoveMembers: false,
-          canChangeRoles: false,
-          canRemoveAdmin: false,
-          canRemovePM: false
-        }
-      }));
-    }
-  }, [projectId, user]);
+  // Cálculo síncrono de permisos (sin llamada de red)
+  const refreshPermissions = useCallback(async (): Promise<void> => {
+    const permissions = MemberService.computePermissions({ isAdmin, isOwner, myRole });
+    setState(prev => ({ ...prev, permissions }));
+  }, [isAdmin, isOwner, myRole]);
+
+  // Recomputa permisos cada vez que cambian miembros, rol de admin o de owner
+  useEffect(() => {
+    const permissions = MemberService.computePermissions({ isAdmin, isOwner, myRole });
+    setState(prev => ({ ...prev, permissions }));
+  }, [isAdmin, isOwner, myRole]);
 
   // Cargar datos iniciales
   useEffect(() => {
     if (projectId && user) {
       loadMembers();
-      refreshPermissions();
     }
-  }, [projectId, user, loadMembers, refreshPermissions]);
+  }, [projectId, user, loadMembers]);
 
   return {
     ...state,
@@ -175,6 +188,7 @@ export function useMembers(projectId: string | null): UseMembersReturn {
     searchUsers,
     addMember,
     removeMember,
+    updateMemberRole,
     clearSearch,
     refreshPermissions
   };

--- a/apps/web/src/hooks/useResources.ts
+++ b/apps/web/src/hooks/useResources.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useState } from 'react';
+import { resourceService } from '../services/resourceService';
+import type { ResourceResponse, CreateResourceDto, UpdateResourceDto } from '@project-workgroup/shared';
+
+interface UseResourcesOptions {
+  status?: 'active' | 'inactive';
+  kind?: 'user' | 'placeholder';
+  search?: string;
+}
+
+export function useResources(options: UseResourcesOptions = {}) {
+  const { status, kind, search } = options;
+  const [resources, setResources] = useState<ResourceResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await resourceService.list({ status, kind, search, limit: 100 });
+      setResources(res.items);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Error al cargar recursos');
+    } finally {
+      setLoading(false);
+    }
+  }, [status, kind, search]);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const create = useCallback(async (dto: CreateResourceDto) => { await resourceService.create(dto); await refresh(); }, [refresh]);
+  const update = useCallback(async (id: string, dto: UpdateResourceDto) => { await resourceService.update(id, dto); await refresh(); }, [refresh]);
+  const linkUser = useCallback(async (id: string, userId: string) => { await resourceService.linkUser(id, userId); await refresh(); }, [refresh]);
+  const remove = useCallback(async (id: string) => { await resourceService.remove(id); await refresh(); }, [refresh]);
+
+  return { resources, loading, error, refresh, create, update, linkUser, remove };
+}
+
+export default useResources;

--- a/apps/web/src/pages/AdminResources.tsx
+++ b/apps/web/src/pages/AdminResources.tsx
@@ -1,0 +1,376 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Plus, Search, Loader2, X, AlertTriangle } from 'lucide-react';
+import { useResources } from '../hooks/useResources';
+import { UserService } from '../services/userService';
+import ResourceModal from '../components/ResourceModal';
+import type { ResourceResponse } from '@project-workgroup/shared';
+import type { User } from '../types/domain';
+
+// Modal de vinculación: busca usuarios (mismo patrón de debounce que MemberManagement) y liga el elegido al recurso placeholder
+interface LinkUserModalProps {
+  resource: ResourceResponse;
+  onClose: () => void;
+  onLink: (userId: string) => Promise<void>;
+}
+
+const LinkUserModal: React.FC<LinkUserModalProps> = ({ resource, onClose, onLink }) => {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<User[]>([]);
+  const [searchLoading, setSearchLoading] = useState(false);
+  const [linkingId, setLinkingId] = useState<string | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    if (query.trim().length < 2) {
+      setResults([]);
+      return;
+    }
+    setSearchLoading(true);
+    timeoutRef.current = setTimeout(async () => {
+      try {
+        const users = await UserService.searchUsersByEmail(query.trim());
+        setResults(users);
+      } finally {
+        setSearchLoading(false);
+      }
+    }, 300);
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, [query]);
+
+  const handleLink = async (userId: string) => {
+    setLinkingId(userId);
+    try {
+      await onLink(userId);
+      onClose();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Error al vincular usuario');
+    } finally {
+      setLinkingId(null);
+    }
+  };
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-head">
+          <h2 className="ttl">Vincular a usuario</h2>
+          <button onClick={onClose} className="btn btn-ghost btn-icon btn-sm" aria-label="Cerrar">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+        <div className="modal-body space-y-4">
+          <p style={{ font: '400 var(--t-small)/1.3 var(--font-sans)', color: 'var(--ink-2)', margin: 0 }}>
+            Vincular <strong>{resource.name}</strong> a una cuenta de usuario existente.
+          </p>
+          <div className="input-wrap">
+            <Search className="lead" />
+            <input
+              autoFocus
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Buscar usuarios por nombre o email…"
+              className="input with-icon"
+            />
+            {searchLoading && (
+              <Loader2
+                className="w-4 h-4 animate-spin absolute right-3 top-1/2 -translate-y-1/2"
+                style={{ color: 'var(--ink-3)' }}
+              />
+            )}
+          </div>
+
+          <div className="space-y-2">
+            {query.trim().length >= 2 && !searchLoading && results.length === 0 && (
+              <p style={{ font: '400 var(--t-small)/1.3 var(--font-sans)', color: 'var(--ink-3)', textAlign: 'center', margin: 0 }}>
+                No se encontraron usuarios
+              </p>
+            )}
+            {results.map((u) => (
+              <div
+                key={u.id}
+                className="flex items-center justify-between gap-3 p-3"
+                style={{ border: '1px solid var(--line)', borderRadius: 'var(--r-md)' }}
+              >
+                <div className="flex items-center gap-3 min-w-0 flex-1">
+                  <span className="avatar" style={{ background: 'var(--p-500)', color: 'var(--ink-on-primary)' }}>
+                    {u.displayName.charAt(0).toUpperCase()}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p style={{ font: '500 var(--t-small)/1.2 var(--font-sans)', color: 'var(--ink-1)', margin: 0 }}>
+                      {u.displayName}
+                    </p>
+                    <p
+                      className="truncate"
+                      style={{ font: '400 var(--t-caption)/1.2 var(--font-mono)', color: 'var(--ink-3)', margin: '2px 0 0' }}
+                    >
+                      {u.email}
+                    </p>
+                  </div>
+                </div>
+                <button
+                  onClick={() => handleLink(u.id)}
+                  disabled={linkingId === u.id}
+                  className="btn btn-primary btn-sm"
+                >
+                  {linkingId === u.id ? <Loader2 className="w-3 h-3 animate-spin" /> : 'Vincular'}
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="modal-foot">
+          <button type="button" onClick={onClose} className="btn btn-secondary">Cerrar</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const KIND_LABEL: Record<ResourceResponse['kind'], string> = {
+  user: 'Usuario',
+  placeholder: 'Placeholder',
+};
+
+export default function AdminResources() {
+  const { resources, loading, error, create, update, linkUser, remove } = useResources({});
+  const [searchQuery, setSearchQuery] = useState('');
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editing, setEditing] = useState<ResourceResponse | null>(null);
+  const [linkingResource, setLinkingResource] = useState<ResourceResponse | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [pendingId, setPendingId] = useState<string | null>(null);
+
+  const filteredResources = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return resources;
+    return resources.filter((r) =>
+      r.name.toLowerCase().includes(q) || (r.email ?? '').toLowerCase().includes(q)
+    );
+  }, [resources, searchQuery]);
+
+  const openCreateModal = () => {
+    setEditing(null);
+    setModalOpen(true);
+  };
+
+  const openEditModal = (resource: ResourceResponse) => {
+    setEditing(resource);
+    setModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setModalOpen(false);
+    setEditing(null);
+  };
+
+  const handleModalSubmit = async (data: { name: string; email?: string; discipline?: string }) => {
+    if (editing) {
+      // Los recursos de kind 'user' tienen name/email gestionados por la identidad vinculada; solo la disciplina es editable
+      const dto = editing.kind === 'user' ? { discipline: data.discipline } : data;
+      await update(editing.id, dto);
+    } else {
+      await create(data);
+    }
+  };
+
+  const handleToggleStatus = async (resource: ResourceResponse) => {
+    setActionError(null);
+    setPendingId(resource.id);
+    try {
+      await update(resource.id, { status: resource.status === 'active' ? 'inactive' : 'active' });
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : 'Error al actualizar el estado');
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const handleRemove = async (resource: ResourceResponse) => {
+    if (!confirm(`¿Eliminar el recurso "${resource.name}"?`)) return;
+    setActionError(null);
+    setPendingId(resource.id);
+    try {
+      await remove(resource.id);
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : 'Error al eliminar el recurso');
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const handleLink = async (userId: string) => {
+    if (!linkingResource) return;
+    await linkUser(linkingResource.id, userId);
+  };
+
+  return (
+    <section className="max-w-5xl mx-auto p-6 sm:p-8 space-y-6">
+      <header className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <p className="eyebrow" style={{ marginBottom: 'var(--s-2)' }}>Administración</p>
+          <h1
+            style={{
+              font: '500 var(--t-h1)/var(--lh-h1) var(--font-sans)',
+              letterSpacing: 'var(--tr-h1)',
+              color: 'var(--ink)',
+              margin: 0,
+            }}
+          >
+            Recursos
+          </h1>
+          <p
+            style={{
+              font: '400 var(--t-small)/var(--lh-small) var(--font-sans)',
+              color: 'var(--ink-2)',
+              margin: 'var(--s-2) 0 0',
+            }}
+          >
+            Personas y placeholders asignables a tareas y workload.
+          </p>
+        </div>
+        <button onClick={openCreateModal} className="btn btn-primary">
+          <Plus className="w-4 h-4" />
+          Nuevo recurso
+        </button>
+      </header>
+
+      <div className="input-wrap max-w-sm">
+        <Search className="lead" />
+        <input
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Buscar por nombre o email…"
+          className="input with-icon"
+        />
+      </div>
+
+      {(error || actionError) && (
+        <div
+          className="flex items-start gap-3"
+          style={{
+            background: 'var(--err-bg)',
+            border: '1px solid var(--err-line)',
+            borderRadius: 'var(--r-lg)',
+            padding: 'var(--s-4)',
+          }}
+        >
+          <AlertTriangle className="w-4 h-4 shrink-0" style={{ color: 'var(--err-fg)' }} />
+          <p style={{ font: '400 var(--t-small)/1.3 var(--font-sans)', color: 'var(--err-fg)', margin: 0 }}>
+            {actionError ?? error}
+          </p>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center gap-2" style={{ color: 'var(--ink-2)' }}>
+          <Loader2 className="w-4 h-4 animate-spin" />
+          <span style={{ font: '400 var(--t-small)/var(--lh-small) var(--font-sans)' }}>Cargando…</span>
+        </div>
+      ) : (
+        <div className="surface-table">
+          <table className="tbl">
+            <thead>
+              <tr>
+                <th>Recurso</th>
+                <th style={{ width: 120 }}>Tipo</th>
+                <th style={{ width: 140 }}>Disciplina</th>
+                <th style={{ width: 110 }}>Estado</th>
+                <th style={{ width: 280 }}>{' '}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredResources.length === 0 && (
+                <tr>
+                  <td colSpan={5} style={{ textAlign: 'center', color: 'var(--ink-3)', padding: 'var(--s-7)' }}>
+                    No hay recursos que coincidan con la búsqueda.
+                  </td>
+                </tr>
+              )}
+              {filteredResources.map((r) => (
+                <tr key={r.id}>
+                  <td>
+                    <div className="flex items-center gap-3 min-w-0">
+                      <span className="avatar" style={{ background: 'var(--p-500)', color: 'var(--ink-on-primary)' }}>
+                        {r.name.charAt(0).toUpperCase()}
+                      </span>
+                      <div className="min-w-0">
+                        <p style={{ font: '500 var(--t-small)/1.2 var(--font-sans)', color: 'var(--ink-1)', margin: 0 }}>
+                          {r.name}
+                        </p>
+                        {r.email && (
+                          <p
+                            className="truncate"
+                            style={{ font: '400 var(--t-caption)/1.2 var(--font-mono)', color: 'var(--ink-3)', margin: '2px 0 0' }}
+                          >
+                            {r.email}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <span className={`badge ${r.kind === 'user' ? 'info' : 'outline'}`}>{KIND_LABEL[r.kind]}</span>
+                  </td>
+                  <td style={{ color: 'var(--ink-2)' }}>{r.discipline ?? '—'}</td>
+                  <td>
+                    <span className={`badge ${r.status === 'active' ? 'ok' : 'warn'}`}>
+                      {r.status === 'active' ? 'Activo' : 'Inactivo'}
+                    </span>
+                  </td>
+                  <td>
+                    <div className="flex items-center justify-end gap-2 flex-wrap">
+                      <button onClick={() => openEditModal(r)} className="btn btn-secondary btn-sm">
+                        Editar
+                      </button>
+                      <button
+                        onClick={() => handleToggleStatus(r)}
+                        disabled={pendingId === r.id}
+                        className="btn btn-secondary btn-sm"
+                      >
+                        {r.status === 'active' ? 'Desactivar' : 'Activar'}
+                      </button>
+                      {r.kind === 'placeholder' && (
+                        <button onClick={() => setLinkingResource(r)} className="btn btn-secondary btn-sm">
+                          Vincular a usuario
+                        </button>
+                      )}
+                      {r.kind === 'placeholder' && (
+                        <button
+                          onClick={() => handleRemove(r)}
+                          disabled={pendingId === r.id}
+                          className="btn btn-danger btn-sm"
+                        >
+                          Eliminar
+                        </button>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <ResourceModal
+        open={modalOpen}
+        onClose={closeModal}
+        onSubmit={handleModalSubmit}
+        initial={editing ? { name: editing.name, email: editing.email, discipline: editing.discipline } : undefined}
+        identityReadOnly={editing?.kind === 'user'}
+      />
+
+      {linkingResource && (
+        <LinkUserModal
+          resource={linkingResource}
+          onClose={() => setLinkingResource(null)}
+          onLink={handleLink}
+        />
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/pages/AdminUsers.tsx
+++ b/apps/web/src/pages/AdminUsers.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useState } from 'react';
+import { AlertTriangle, Loader2 } from 'lucide-react';
+import { UserService } from '../services/userService';
+import { ApiError } from '../lib/apiClient';
+import type { UserResponse, GlobalRole, UserStatus } from '@project-workgroup/shared';
+
+const ROLE_OPTIONS: GlobalRole[] = ['admin', 'pm', 'member'];
+
+export default function AdminUsers() {
+  const [users, setUsers] = useState<UserResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingId, setPendingId] = useState<string | null>(null);
+
+  const refresh = () =>
+    UserService.adminListUsers()
+      .then(setUsers)
+      .catch((e) => setError(e instanceof Error ? e.message : 'Error al cargar usuarios'))
+      .finally(() => setLoading(false));
+
+  useEffect(() => { refresh(); }, []);
+
+  const handleRoleChange = async (id: string, role: GlobalRole) => {
+    setError(null);
+    setPendingId(id);
+    try {
+      await UserService.adminUpdateUser(id, { role });
+      await refresh();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : 'Error al actualizar el rol');
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const handleToggleStatus = async (id: string, current: UserStatus) => {
+    const next: UserStatus = current === 'active' ? 'disabled' : 'active';
+    setError(null);
+    setPendingId(id);
+    try {
+      await UserService.adminUpdateUser(id, { status: next });
+      await refresh();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : 'Error al actualizar el estado');
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  return (
+    <section className="max-w-4xl mx-auto p-6 sm:p-8 space-y-6">
+      <header>
+        <p className="eyebrow" style={{ marginBottom: 'var(--s-2)' }}>Administración</p>
+        <h1
+          style={{
+            font: '500 var(--t-h1)/var(--lh-h1) var(--font-sans)',
+            letterSpacing: 'var(--tr-h1)',
+            color: 'var(--ink)',
+            margin: 0,
+          }}
+        >
+          Usuarios
+        </h1>
+        <p
+          style={{
+            font: '400 var(--t-small)/var(--lh-small) var(--font-sans)',
+            color: 'var(--ink-2)',
+            margin: 'var(--s-2) 0 0',
+          }}
+        >
+          Gestiona roles y estado de acceso de los usuarios.
+        </p>
+      </header>
+
+      {error && (
+        <div
+          className="flex items-start gap-3"
+          style={{
+            background: 'var(--err-bg)',
+            border: '1px solid var(--err-line)',
+            borderRadius: 'var(--r-lg)',
+            padding: 'var(--s-4)',
+          }}
+        >
+          <AlertTriangle className="w-4 h-4 shrink-0" style={{ color: 'var(--err-fg)' }} />
+          <p style={{ font: '400 var(--t-small)/1.3 var(--font-sans)', color: 'var(--err-fg)', margin: 0 }}>
+            {error}
+          </p>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center gap-2" style={{ color: 'var(--ink-2)' }}>
+          <Loader2 className="w-4 h-4 animate-spin" />
+          <span style={{ font: '400 var(--t-small)/var(--lh-small) var(--font-sans)' }}>Cargando…</span>
+        </div>
+      ) : (
+        <div className="surface-table">
+          <table className="tbl">
+            <thead>
+              <tr>
+                <th>Usuario</th>
+                <th style={{ width: 140 }}>Rol</th>
+                <th style={{ width: 140 }}>Estado</th>
+                <th style={{ width: 100 }}>{' '}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.length === 0 && (
+                <tr>
+                  <td colSpan={4} style={{ textAlign: 'center', color: 'var(--ink-3)', padding: 'var(--s-7)' }}>
+                    No hay usuarios todavía.
+                  </td>
+                </tr>
+              )}
+              {users.map((u) => (
+                <tr key={u.id}>
+                  <td>
+                    <div className="flex items-center gap-3 min-w-0">
+                      <span
+                        className="avatar"
+                        style={{ background: 'var(--p-500)', color: 'var(--ink-on-primary)' }}
+                      >
+                        {u.displayName.charAt(0).toUpperCase()}
+                      </span>
+                      <div className="min-w-0">
+                        <p style={{ font: '500 var(--t-small)/1.2 var(--font-sans)', color: 'var(--ink-1)', margin: 0 }}>
+                          {u.displayName}
+                        </p>
+                        <p
+                          className="truncate"
+                          style={{ font: '400 var(--t-caption)/1.2 var(--font-mono)', color: 'var(--ink-3)', margin: '2px 0 0' }}
+                        >
+                          {u.email}
+                        </p>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <select
+                      className="select"
+                      value={u.role}
+                      disabled={pendingId === u.id}
+                      onChange={(e) => handleRoleChange(u.id, e.target.value as GlobalRole)}
+                    >
+                      {ROLE_OPTIONS.map((r) => (
+                        <option key={r} value={r}>{r}</option>
+                      ))}
+                    </select>
+                  </td>
+                  <td>
+                    <span className={`badge ${u.status === 'active' ? 'ok' : 'warn'}`}>
+                      {u.status === 'active' ? 'Activo' : 'Deshabilitado'}
+                    </span>
+                  </td>
+                  <td style={{ textAlign: 'right' }}>
+                    <button
+                      onClick={() => handleToggleStatus(u.id, u.status)}
+                      disabled={pendingId === u.id}
+                      className={`btn btn-sm ${u.status === 'active' ? 'btn-danger' : 'btn-secondary'}`}
+                    >
+                      {u.status === 'active' ? 'Deshabilitar' : 'Activar'}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/pages/AdminUsers.tsx
+++ b/apps/web/src/pages/AdminUsers.tsx
@@ -1,16 +1,159 @@
-import { useEffect, useState } from 'react';
-import { AlertTriangle, Loader2 } from 'lucide-react';
+import { useEffect, useState, type FormEvent } from 'react';
+import { AlertTriangle, Loader2, UserPlus, X } from 'lucide-react';
 import { UserService } from '../services/userService';
 import { ApiError } from '../lib/apiClient';
 import type { UserResponse, GlobalRole, UserStatus } from '@project-workgroup/shared';
 
 const ROLE_OPTIONS: GlobalRole[] = ['admin', 'pm', 'member'];
 
+interface CreateUserModalProps {
+  onClose: () => void;
+  onCreated: () => Promise<void>;
+}
+
+function CreateUserModal({ onClose, onCreated }: CreateUserModalProps) {
+  const [email, setEmail] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [password, setPassword] = useState('');
+  const [role, setRole] = useState<GlobalRole>('member');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const passwordTooShort = password.length > 0 && password.length < 6;
+  const isValid = email.trim() !== '' && displayName.trim() !== '' && password.length >= 6;
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!isValid) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await UserService.adminCreateUser({
+        email: email.trim(),
+        displayName: displayName.trim(),
+        password,
+        role,
+      });
+      await onCreated();
+      onClose();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : 'Error al crear el usuario');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-head">
+          <h2 className="ttl">Crear Usuario</h2>
+          <button onClick={onClose} className="btn btn-ghost btn-icon btn-sm" disabled={saving} aria-label="Cerrar">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="contents">
+          <div className="modal-body space-y-4">
+            <div className="field">
+              <label htmlFor="cu-email" className="field-label">Email *</label>
+              <input
+                type="email"
+                id="cu-email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="input"
+                placeholder="usuario@empresa.com"
+                disabled={saving}
+                required
+              />
+            </div>
+
+            <div className="field">
+              <label htmlFor="cu-displayName" className="field-label">Nombre para mostrar *</label>
+              <input
+                type="text"
+                id="cu-displayName"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                className="input"
+                placeholder="Nombre Apellido"
+                disabled={saving}
+                required
+              />
+            </div>
+
+            <div className="field">
+              <label htmlFor="cu-password" className="field-label">Contraseña *</label>
+              <input
+                type="password"
+                id="cu-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="input"
+                placeholder="Mínimo 6 caracteres"
+                disabled={saving}
+                required
+              />
+              {passwordTooShort && (
+                <p style={{ color: 'var(--err-fg)', font: '400 var(--t-caption)/1.3 var(--font-sans)', margin: '4px 0 0' }}>
+                  La contraseña debe tener al menos 6 caracteres
+                </p>
+              )}
+            </div>
+
+            <div className="field">
+              <label htmlFor="cu-role" className="field-label">Rol</label>
+              <select
+                id="cu-role"
+                value={role}
+                onChange={(e) => setRole(e.target.value as GlobalRole)}
+                className="select"
+                disabled={saving}
+              >
+                {ROLE_OPTIONS.map((r) => (
+                  <option key={r} value={r}>{r}</option>
+                ))}
+              </select>
+            </div>
+
+            {error && (
+              <div
+                style={{
+                  background: 'var(--err-bg)',
+                  border: '1px solid var(--err-line)',
+                  color: 'var(--err-fg)',
+                  borderRadius: 'var(--r-md)',
+                  padding: 'var(--s-3) var(--s-4)',
+                  font: '400 var(--t-small)/var(--lh-small) var(--font-sans)',
+                }}
+              >
+                {error}
+              </div>
+            )}
+          </div>
+
+          <div className="modal-foot">
+            <button type="button" onClick={onClose} className="btn btn-secondary" disabled={saving}>
+              Cancelar
+            </button>
+            <button type="submit" className="btn btn-primary" disabled={saving || !isValid}>
+              {saving && <Loader2 className="w-4 h-4 animate-spin" />}
+              Crear
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
 export default function AdminUsers() {
   const [users, setUsers] = useState<UserResponse[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [pendingId, setPendingId] = useState<string | null>(null);
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
 
   const refresh = () =>
     UserService.adminListUsers()
@@ -49,27 +192,33 @@ export default function AdminUsers() {
 
   return (
     <section className="max-w-4xl mx-auto p-6 sm:p-8 space-y-6">
-      <header>
-        <p className="eyebrow" style={{ marginBottom: 'var(--s-2)' }}>Administración</p>
-        <h1
-          style={{
-            font: '500 var(--t-h1)/var(--lh-h1) var(--font-sans)',
-            letterSpacing: 'var(--tr-h1)',
-            color: 'var(--ink)',
-            margin: 0,
-          }}
-        >
-          Usuarios
-        </h1>
-        <p
-          style={{
-            font: '400 var(--t-small)/var(--lh-small) var(--font-sans)',
-            color: 'var(--ink-2)',
-            margin: 'var(--s-2) 0 0',
-          }}
-        >
-          Gestiona roles y estado de acceso de los usuarios.
-        </p>
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <p className="eyebrow" style={{ marginBottom: 'var(--s-2)' }}>Administración</p>
+          <h1
+            style={{
+              font: '500 var(--t-h1)/var(--lh-h1) var(--font-sans)',
+              letterSpacing: 'var(--tr-h1)',
+              color: 'var(--ink)',
+              margin: 0,
+            }}
+          >
+            Usuarios
+          </h1>
+          <p
+            style={{
+              font: '400 var(--t-small)/var(--lh-small) var(--font-sans)',
+              color: 'var(--ink-2)',
+              margin: 'var(--s-2) 0 0',
+            }}
+          >
+            Gestiona roles y estado de acceso de los usuarios.
+          </p>
+        </div>
+        <button onClick={() => setIsCreateOpen(true)} className="btn btn-primary shrink-0">
+          <UserPlus className="w-4 h-4" />
+          Crear usuario
+        </button>
       </header>
 
       {error && (
@@ -167,6 +316,10 @@ export default function AdminUsers() {
             </tbody>
           </table>
         </div>
+      )}
+
+      {isCreateOpen && (
+        <CreateUserModal onClose={() => setIsCreateOpen(false)} onCreated={refresh} />
       )}
     </section>
   );

--- a/apps/web/src/pages/ProjectView.tsx
+++ b/apps/web/src/pages/ProjectView.tsx
@@ -183,7 +183,13 @@ const ProjectView: React.FC = () => {
   );
 
   const assigneeOptions = React.useMemo(
-    () => resources.map((r) => ({ id: r.id, displayName: r.name, avatar: r.avatarUrl ?? undefined })),
+    () =>
+      resources.map((r) => ({
+        id: r.id,
+        displayName: r.name,
+        avatar: r.avatarUrl ?? undefined,
+        discipline: r.discipline ?? undefined,
+      })),
     [resources],
   );
 
@@ -200,6 +206,7 @@ const ProjectView: React.FC = () => {
         progress?: number;
         startDate?: string;
         endDate?: string;
+        assigneeId?: string | null;
       },
       expectedVersion?: number,
     ) => {
@@ -214,6 +221,7 @@ const ProjectView: React.FC = () => {
           ...(patch.startDate !== undefined && { startDate: patch.startDate }),
           ...(patch.endDate !== undefined && { endDate: patch.endDate }),
           ...(patch.progress !== undefined && { progress: patch.progress }),
+          ...(patch.assigneeId !== undefined && { assigneeId: patch.assigneeId ?? '' }),
           ...(expectedVersion !== undefined && { expectedVersion }),
         });
         applyTasksPayload({

--- a/apps/web/src/pages/ProjectView.tsx
+++ b/apps/web/src/pages/ProjectView.tsx
@@ -5,7 +5,7 @@ import 'wx-react-gantt/dist/gantt.css';
 import '../styles/gantt-custom.css';
 import { useTasks } from '../hooks/usetasks';
 import { useProject } from '../hooks/useProject';
-import { useMembers } from '../hooks/useMembers';
+import { useResources } from '../hooks/useResources';
 import { useAuth } from '../contexts/AuthContext';
 import { useNavigation } from '../contexts/NavigationContext';
 import { ProjectActions, ProjectMeta } from '../components/Layout';
@@ -25,6 +25,9 @@ import type { WorkingCalendarResponse } from '@project-workgroup/shared';
 import type { Task, TaskLink, TaskPriority, TaskStatus, TaskType } from '../types/domain';
 import type { GanttApi } from 'wx-react-gantt';
 
+// Referencia estable para no reiniciar useResources en cada render.
+const ACTIVE_RESOURCE_FILTER = { status: 'active' } as const;
+
 const ProjectView: React.FC = () => {
   const { projectId } = useParams<{ projectId: string }>();
   const navigate = useNavigate();
@@ -37,7 +40,7 @@ const ProjectView: React.FC = () => {
   const { tasks, loading: tasksLoading, error: tasksError, refetch: refetchTasks } = useTasks(projectId);
   const { data: taskLinks = [] } = useProjectTaskLinksQuery(user ? projectId : undefined);
   const { data: projectSettings } = useProjectSettingsQuery(user ? projectId : undefined);
-  const { members, loadMembers } = useMembers(projectId ?? null);
+  const { resources } = useResources(ACTIVE_RESOURCE_FILTER);
   const [calendar, setCalendar] = React.useState<WorkingCalendarResponse | null>(null);
 
   React.useEffect(() => {
@@ -101,12 +104,6 @@ const ProjectView: React.FC = () => {
     },
     [projectId, queryClient],
   );
-
-  React.useEffect(() => {
-    if (projectId) {
-      loadMembers();
-    }
-  }, [projectId, loadMembers]);
 
   const handleOpenCalendar = React.useCallback(() => {
     if (projectId) navigate(`/project/${projectId}/settings`);
@@ -186,8 +183,8 @@ const ProjectView: React.FC = () => {
   );
 
   const assigneeOptions = React.useMemo(
-    () => members.map((m) => ({ id: m.userId, displayName: m.displayName, avatar: m.avatar })),
-    [members],
+    () => resources.map((r) => ({ id: r.id, displayName: r.name, avatar: r.avatarUrl ?? undefined })),
+    [resources],
   );
 
   const handleUpdateTaskInline = React.useCallback(

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Key, Clock, User, ChevronRight } from 'lucide-react';
+import { Key, Clock, User, ChevronRight, Users, Contact } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
+import { useUserRole } from '../hooks/useUserRole';
 import { calendarService } from '../services/calendarService';
 import type { WorkingCalendarResponse } from '@project-workgroup/shared';
 
@@ -64,6 +65,7 @@ const SettingsCard: React.FC<SettingsCardProps> = ({ to, icon, title, descriptio
 
 export default function SettingsPage() {
   const { user } = useAuth();
+  const { isAdmin } = useUserRole();
   const [globalCal, setGlobalCal] = useState<WorkingCalendarResponse | null>(null);
 
   useEffect(() => {
@@ -120,6 +122,26 @@ export default function SettingsPage() {
           meta={globalCal ? `${globalCal.hoursPerDay} h/día · ${globalCal.timezone}` : undefined}
         />
       </div>
+
+      {isAdmin && (
+        <div className="space-y-3">
+          <p className="eyebrow" style={{ marginBottom: 'var(--s-2)' }}>Administración</p>
+
+          <SettingsCard
+            to="/admin/users"
+            icon={<Users className="w-5 h-5" />}
+            title="Usuarios"
+            description="Roles y estado de acceso de los usuarios"
+          />
+
+          <SettingsCard
+            to="/admin/resources"
+            icon={<Contact className="w-5 h-5" />}
+            title="Recursos"
+            description="Personas y placeholders asignables a tareas y workload"
+          />
+        </div>
+      )}
     </section>
   );
 }

--- a/apps/web/src/services/ganttDataProvider.ts
+++ b/apps/web/src/services/ganttDataProvider.ts
@@ -143,6 +143,7 @@ export class GanttDataProvider {
         cached.type === fresh.type &&
         cached.parentId === fresh.parentId &&
         cached.order === fresh.order &&
+        cached.assigneeId === fresh.assigneeId &&
         cached.open === fresh.open;
       if (sameShape) continue;
 
@@ -422,7 +423,8 @@ export class GanttDataProvider {
       hoursPerDay: Number.isFinite(task.hoursPerDay) ? task.hoursPerDay : undefined,
       status: task.status,
       priority: task.priority,
-    } as GanttTask & { status: string; priority: string };
+      assigneeId: task.assigneeId ?? null,
+    } as GanttTask & { status: string; priority: string; assigneeId: string | null };
 
     if (childrenByParent) {
       const hasChildren = childrenByParent.has(task.id);

--- a/apps/web/src/services/memberService.ts
+++ b/apps/web/src/services/memberService.ts
@@ -1,5 +1,5 @@
 import { apiClient } from '../lib/apiClient';
-import type { UserResponse, PagedResponse } from '@project-workgroup/shared';
+import type { UserResponse, PagedResponse, ProjectMemberResponse, ProjectRole } from '@project-workgroup/shared';
 import type {
   UserSearchResult,
   MemberSearchFilters,
@@ -36,20 +36,24 @@ export class MemberService {
 
   static async getProjectMembers(projectId: string): Promise<ProjectMember[]> {
     try {
-      const rows = await apiClient.get<Array<{ user: UserResponse; projectRole: string }>>(`/v1/projects/${projectId}/members`);
+      const rows = await apiClient.get<ProjectMemberResponse[]>(`/v1/projects/${projectId}/members`);
       return rows.map(r => ({
         userId: r.user.id,
         email: r.user.email,
         displayName: r.user.displayName,
-        role: 'member' as const,
+        role: r.projectRole,
         avatar: r.user.avatarUrl ?? undefined,
-        joinedAt: '',
+        joinedAt: r.createdAt,
         addedBy: '',
       }));
     } catch (error) {
       console.error('Error getting project members:', error);
       throw error;
     }
+  }
+
+  static async updateMemberRole(projectId: string, userId: string, projectRole: ProjectRole): Promise<void> {
+    await apiClient.patch(`/v1/projects/${projectId}/members/${userId}`, { projectRole });
   }
 
   static async addMember(projectId: string, userId: string, _performedBy: string): Promise<void> {
@@ -60,14 +64,13 @@ export class MemberService {
     await apiClient.delete(`/v1/projects/${projectId}/members/${userId}`);
   }
 
-  static async getMemberManagementPermissions(
-    _projectId: string,
-    _userId: string
-  ): Promise<MemberManagementPermissions> {
+  // Cálculo síncrono de permisos (sin llamada de red): admin/owner/manager pueden gestionar miembros.
+  static computePermissions(input: { isAdmin: boolean; isOwner: boolean; myRole: ProjectRole | null }): MemberManagementPermissions {
+    const canManage = input.isAdmin || input.isOwner || input.myRole === 'manager';
     return {
-      canAddMembers: true,
-      canRemoveMembers: true,
-      canChangeRoles: false,
+      canAddMembers: canManage,
+      canRemoveMembers: canManage,
+      canChangeRoles: canManage,
       canRemoveAdmin: false,
       canRemovePM: false,
     };

--- a/apps/web/src/services/resourceService.ts
+++ b/apps/web/src/services/resourceService.ts
@@ -1,0 +1,32 @@
+import { apiClient } from '../lib/apiClient';
+import type {
+  CreateResourceDto,
+  UpdateResourceDto,
+  ResourceResponse,
+  PagedResponse,
+} from '@project-workgroup/shared';
+
+export interface ListResourcesParams {
+  search?: string;
+  kind?: 'user' | 'placeholder';
+  status?: 'active' | 'inactive';
+  cursor?: string;
+  limit?: number;
+}
+
+export const resourceService = {
+  list: (params: ListResourcesParams = {}) => {
+    const qs = new URLSearchParams();
+    if (params.search) qs.set('search', params.search);
+    if (params.kind) qs.set('kind', params.kind);
+    if (params.status) qs.set('status', params.status);
+    if (params.cursor) qs.set('cursor', params.cursor);
+    if (params.limit) qs.set('limit', String(params.limit));
+    const q = qs.toString();
+    return apiClient.get<PagedResponse<ResourceResponse>>(`/v1/resources${q ? `?${q}` : ''}`);
+  },
+  create: (dto: CreateResourceDto) => apiClient.post<ResourceResponse>('/v1/resources', dto),
+  update: (id: string, dto: UpdateResourceDto) => apiClient.patch<ResourceResponse>(`/v1/resources/${id}`, dto),
+  linkUser: (id: string, userId: string) => apiClient.patch<ResourceResponse>(`/v1/resources/${id}/link-user`, { userId }),
+  remove: (id: string) => apiClient.delete(`/v1/resources/${id}`),
+};

--- a/apps/web/src/services/userService.ts
+++ b/apps/web/src/services/userService.ts
@@ -77,6 +77,18 @@ export class UserService {
     const result = await apiClient.post<UserResponse>('/v1/auth/sync', {});
     return toDomain(result);
   }
+
+  static async adminListUsers(): Promise<UserResponse[]> {
+    const res = await apiClient.get<PagedResponse<UserResponse>>('/v1/users');
+    return res.items;
+  }
+
+  static async adminUpdateUser(
+    id: string,
+    dto: { role?: 'admin' | 'pm' | 'member'; status?: 'active' | 'disabled' }
+  ): Promise<UserResponse> {
+    return apiClient.patch<UserResponse>(`/v1/users/${id}`, dto);
+  }
 }
 
 export default UserService;

--- a/apps/web/src/services/userService.ts
+++ b/apps/web/src/services/userService.ts
@@ -89,6 +89,15 @@ export class UserService {
   ): Promise<UserResponse> {
     return apiClient.patch<UserResponse>(`/v1/users/${id}`, dto);
   }
+
+  static async adminCreateUser(dto: {
+    email: string;
+    displayName: string;
+    password: string;
+    role?: 'admin' | 'pm' | 'member';
+  }): Promise<UserResponse> {
+    return apiClient.post<UserResponse>('/v1/users', dto);
+  }
 }
 
 export default UserService;

--- a/apps/web/src/types/domain.ts
+++ b/apps/web/src/types/domain.ts
@@ -1,3 +1,5 @@
+import type { ProjectRole } from '@project-workgroup/shared';
+
 // Tipos base
 export type UserRole = 'admin' | 'pm' | 'member';
 export type ProjectStatus = 'planning' | 'active' | 'completed' | 'on-hold';
@@ -410,7 +412,7 @@ export interface ProjectMember {
   userId: string;
   email: string;
   displayName: string;
-  role: UserRole;
+  role: ProjectRole;
   avatar?: string;
   joinedAt: string;
   addedBy: string;

--- a/apps/web/src/utils/ganttAssigneeCells.ts
+++ b/apps/web/src/utils/ganttAssigneeCells.ts
@@ -1,0 +1,68 @@
+import type { GanttApi } from 'wx-react-gantt';
+
+export interface AssigneeCellInfo {
+  displayName: string;
+  avatar?: string;
+  discipline?: string;
+}
+
+const initialsOf = (name: string): string =>
+  name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((w) => w[0] ?? '')
+    .join('')
+    .toUpperCase() || '?';
+
+const AVATAR_STYLE =
+  'display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;border-radius:999px;font:600 10px/1 var(--font-sans);overflow:hidden;vertical-align:middle';
+
+// El grid de wx-react-gantt renderiza el `template` como texto (escapa HTML), así que el
+// avatar se inyecta aquí por DOM. Se construye con createElement/textContent (sin innerHTML)
+// para ser seguro ante XSS: nombre/disciplina/URL van como propiedades, no se parsean como HTML.
+const buildBadge = (a: AssigneeCellInfo | undefined, key: string): HTMLElement => {
+  const span = document.createElement('span');
+  span.setAttribute('data-pwg-assignee', key);
+  if (!a) {
+    span.style.color = 'var(--ink-3)';
+    span.textContent = '—';
+    return span;
+  }
+  span.style.cssText = AVATAR_STYLE;
+  span.title = a.discipline ? `${a.displayName} — ${a.discipline}` : a.displayName;
+  if (a.avatar) {
+    const img = document.createElement('img');
+    img.src = a.avatar;
+    img.alt = '';
+    img.style.cssText = 'width:100%;height:100%;object-fit:cover';
+    span.appendChild(img);
+  } else {
+    span.style.background = 'var(--p-100)';
+    span.style.color = 'var(--p-700)';
+    span.textContent = initialsOf(a.displayName);
+  }
+  return span;
+};
+
+export function applyAssigneeCells(
+  api: GanttApi | null,
+  container: HTMLElement | null,
+  assigneesById: Map<string, AssigneeCellInfo>,
+): void {
+  if (!api || !container) return;
+  const cells = container.querySelectorAll<HTMLElement>('.wx-cell[data-col-id="assignee"]');
+  cells.forEach((cell) => {
+    const rowId = cell.getAttribute('data-row-id');
+    if (!rowId) return;
+    const task = api.getTask(rowId) as { assigneeId?: string | null } | undefined;
+    const assigneeId = task?.assigneeId ? String(task.assigneeId) : null;
+    const a = assigneeId ? assigneesById.get(assigneeId) : undefined;
+    const key = a ? assigneeId! : 'none';
+    // Guard idempotente: si ya está renderizado para esta misma asignación, no reescribir
+    // (evita un bucle con el MutationObserver y trabajo redundante en cada scroll).
+    const existing = cell.querySelector('[data-pwg-assignee]');
+    if (existing?.getAttribute('data-pwg-assignee') === key) return;
+    cell.replaceChildren(buildBadge(a, key));
+  });
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "project-workgroup",
   "private": true,
-  "version": "2.1.0",
+  "version": "3.0.0",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/packages/mcp/src/apiClient.spec.ts
+++ b/packages/mcp/src/apiClient.spec.ts
@@ -42,6 +42,18 @@ describe('createApiClient', () => {
     expect(result.items).toEqual(items);
   });
 
+  it('builds the resources search query and forces status=active', async () => {
+    const items = [
+      { id: '3', name: 'Ana', email: 'ana@x.com', kind: 'user', status: 'active', userId: '30', avatarUrl: null, discipline: null, createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+    ];
+    fetchMock.mockResolvedValueOnce(okJson({ items, nextCursor: null }));
+    const result = await client().searchResources({ search: 'ana', limit: 5 });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'http://api.test/v1/resources?search=ana&limit=5&status=active',
+    );
+    expect(result.items).toEqual(items);
+  });
+
   it('translates the error envelope into an ApiError', async () => {
     fetchMock.mockResolvedValueOnce(
       okJson(

--- a/packages/mcp/src/apiClient.ts
+++ b/packages/mcp/src/apiClient.ts
@@ -3,6 +3,7 @@ import type {
   ProjectResponse,
   TaskResponse,
   UserResponse,
+  ResourceResponse,
   PagedResponse,
   CreateTaskDto,
   UpdateTaskDto,
@@ -42,6 +43,10 @@ export interface ApiClient {
     search?: string;
     limit?: number;
   }): Promise<PagedResponse<UserResponse>>;
+  searchResources(params: {
+    search?: string;
+    limit?: number;
+  }): Promise<PagedResponse<ResourceResponse>>;
   createTask(projectId: string, dto: CreateTaskDto): Promise<TaskResponse>;
   updateTask(id: string, dto: UpdateTaskDto): Promise<TaskMutationResponse>;
   bulkUpdateTasks(
@@ -145,6 +150,18 @@ export function createApiClient(config: ApiClientConfig): ApiClient {
       return request<PagedResponse<UserResponse>>(
         'GET',
         `/v1/users${query ? `?${query}` : ''}`,
+      );
+    },
+    searchResources: ({ search, limit }) => {
+      const qs = new URLSearchParams();
+      if (search) qs.set('search', search);
+      if (limit !== undefined) qs.set('limit', String(limit));
+      // Solo recursos activos: uno inactivo no debería ser asignable a tareas nuevas.
+      qs.set('status', 'active');
+      const query = qs.toString();
+      return request<PagedResponse<ResourceResponse>>(
+        'GET',
+        `/v1/resources${query ? `?${query}` : ''}`,
       );
     },
 

--- a/packages/mcp/src/tools/read-tools.spec.ts
+++ b/packages/mcp/src/tools/read-tools.spec.ts
@@ -19,6 +19,7 @@ const clientStub = (over: Partial<ApiClient> = {}): ApiClient => ({
   listTasks: vi.fn(),
   getTask: vi.fn(),
   searchUsers: vi.fn().mockResolvedValue({ items: [], nextCursor: null }),
+  searchResources: vi.fn().mockResolvedValue({ items: [], nextCursor: null }),
   createTask: vi.fn(),
   updateTask: vi.fn(),
   bulkUpdateTasks: vi.fn(),

--- a/packages/mcp/src/tools/write-tools.spec.ts
+++ b/packages/mcp/src/tools/write-tools.spec.ts
@@ -8,7 +8,7 @@ function makeServerSpy() {
 }
 const clientStub = (over: Partial<ApiClient> = {}): ApiClient => ({
   listProjects: vi.fn(), getProject: vi.fn(), listTasks: vi.fn(),
-  getTask: vi.fn(), searchUsers: vi.fn(),
+  getTask: vi.fn(), searchUsers: vi.fn(), searchResources: vi.fn(),
   createTask: vi.fn(), updateTask: vi.fn(), bulkUpdateTasks: vi.fn(),
   propagatePreview: vi.fn(), propagateApply: vi.fn(), importProject: vi.fn(),
   ...over,
@@ -37,22 +37,22 @@ describe('registerWriteTools — fine tools', () => {
   });
 
   it('assign_task resolves a single person and assigns', async () => {
-    const searchUsers = vi.fn().mockResolvedValue({ items: [{ id: '3', displayName: 'Ana', email: 'ana@x', role: 'pm', avatarUrl: null }], nextCursor: null });
+    const searchResources = vi.fn().mockResolvedValue({ items: [{ id: '3', name: 'Ana', email: 'ana@x', kind: 'user', status: 'active', userId: '30', avatarUrl: null, discipline: null, createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' }], nextCursor: null });
     const getTask = vi.fn().mockResolvedValue({ id: '5', version: 2 });
     const updateTask = vi.fn().mockResolvedValue({ id: '5', version: 3, assigneeId: '3', summariesPatched: [] });
     const { server, handlers } = makeServerSpy();
-    registerWriteTools(server, clientStub({ searchUsers, getTask, updateTask }));
+    registerWriteTools(server, clientStub({ searchResources, getTask, updateTask }));
     const res = await handlers.get('assign_task')!({ taskId: '5', person: 'ana' });
     expect(updateTask.mock.calls[0][1]).toMatchObject({ assigneeId: '3', expectedVersion: 2 });
     expect(res.content[0].text).toContain('Ana');
   });
 
   it('assign_task lists candidates when the query is ambiguous', async () => {
-    const searchUsers = vi.fn().mockResolvedValue({ items: [{ id: '3', displayName: 'Ana Uno', email: 'a1@x', role: 'pm', avatarUrl: null }, { id: '4', displayName: 'Ana Dos', email: 'a2@x', role: 'member', avatarUrl: null }], nextCursor: null });
+    const searchResources = vi.fn().mockResolvedValue({ items: [{ id: '3', name: 'Ana Uno', email: 'a1@x', kind: 'user', status: 'active', userId: '30', avatarUrl: null, discipline: null, createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' }, { id: '4', name: 'Ana Dos', email: 'a2@x', kind: 'user', status: 'active', userId: '31', avatarUrl: null, discipline: null, createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' }], nextCursor: null });
     const { server, handlers } = makeServerSpy();
-    registerWriteTools(server, clientStub({ searchUsers }));
+    registerWriteTools(server, clientStub({ searchResources }));
     const res = await handlers.get('assign_task')!({ taskId: '5', person: 'ana' });
-    expect(res.content[0].text).toContain('varias');
+    expect(res.content[0].text).toContain('varios');
     expect(res.content[0].text).toContain('a1@x');
   });
 });

--- a/packages/mcp/src/tools/write-tools.ts
+++ b/packages/mcp/src/tools/write-tools.ts
@@ -173,25 +173,25 @@ export function registerWriteTools(server: McpServer, client: ApiClient): void {
     },
     async ({ taskId, person }) => {
       try {
-        const page = await client.searchUsers({ search: person, limit: 10 });
+        const page = await client.searchResources({ search: person, limit: 10 });
         if (page.items.length === 0)
-          return textResult(`No encontré a nadie que coincida con "${person}".`);
+          return textResult(`No encontré ningún recurso que coincida con "${person}".`);
         if (page.items.length > 1) {
           const lines = page.items
-            .map((u) => `- [${u.id}] ${u.displayName} <${u.email}>`)
+            .map((r) => `- [${r.id}] ${r.name} <${r.email ?? 'sin email'}>`)
             .join('\n');
           return textResult(
-            `Hay varias coincidencias para "${person}"; vuelve a llamar con el email exacto:\n${lines}`,
+            `Hay varios recursos que coinciden con "${person}"; vuelve a llamar con el email exacto:\n${lines}`,
           );
         }
-        const user = page.items[0];
+        const resource = page.items[0];
         const current = await client.getTask(taskId);
         const res = await client.updateTask(taskId, {
-          assigneeId: user.id,
+          assigneeId: resource.id,
           expectedVersion: current.version,
         });
         return textResult(
-          `Asignada [${res.id}] ${res.name} a ${user.displayName} <${user.email}>.`,
+          `Asignada [${res.id}] ${res.name} a ${resource.name} <${resource.email ?? 'sin email'}>.`,
         );
       } catch (err) {
         return errorResult(err);

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-workgroup/shared",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "private": true,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/shared/src/dto/project-member.dto.ts
+++ b/packages/shared/src/dto/project-member.dto.ts
@@ -1,4 +1,5 @@
 import { IsIn, IsString } from 'class-validator';
+import { UserResponse } from './user.dto';
 
 export const PROJECT_ROLES = ['manager', 'contributor', 'viewer'] as const;
 export type ProjectRole = (typeof PROJECT_ROLES)[number];
@@ -15,5 +16,11 @@ export interface ProjectMemberResponse {
   projectId: string;
   userId: string;
   projectRole: ProjectRole;
+  user: UserResponse;
   createdAt: string;
+}
+
+export class UpdateProjectMemberDto {
+  @IsIn(PROJECT_ROLES)
+  projectRole!: ProjectRole;
 }

--- a/packages/shared/src/dto/resource.dto.ts
+++ b/packages/shared/src/dto/resource.dto.ts
@@ -1,0 +1,84 @@
+import { Type } from 'class-transformer';
+import {
+  IsEmail,
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Min,
+  MinLength,
+} from 'class-validator';
+
+export const RESOURCE_KINDS = ['user', 'placeholder'] as const;
+export type ResourceKind = (typeof RESOURCE_KINDS)[number];
+
+export const RESOURCE_STATUSES = ['active', 'inactive'] as const;
+export type ResourceStatus = (typeof RESOURCE_STATUSES)[number];
+
+export class CreateResourceDto {
+  @IsString() @MinLength(1) @MaxLength(200)
+  name!: string;
+
+  @IsOptional() @IsEmail()
+  email?: string;
+
+  @IsOptional() @IsString()
+  avatarUrl?: string;
+
+  @IsOptional() @IsString() @MaxLength(100)
+  discipline?: string;
+}
+
+export class UpdateResourceDto {
+  @IsOptional() @IsString() @MinLength(1) @MaxLength(200)
+  name?: string;
+
+  @IsOptional() @IsEmail()
+  email?: string;
+
+  @IsOptional() @IsString()
+  avatarUrl?: string;
+
+  @IsOptional() @IsString() @MaxLength(100)
+  discipline?: string;
+
+  @IsOptional() @IsIn(RESOURCE_STATUSES)
+  status?: ResourceStatus;
+}
+
+export class LinkResourceUserDto {
+  @IsString()
+  userId!: string;
+}
+
+export class ListResourcesQueryDto {
+  @IsOptional() @IsString() @MinLength(1)
+  search?: string;
+
+  @IsOptional() @IsIn(RESOURCE_KINDS)
+  kind?: ResourceKind;
+
+  @IsOptional() @IsIn(RESOURCE_STATUSES)
+  status?: ResourceStatus;
+
+  // El query param llega como string; coacciona a número antes de validar
+  @IsOptional() @Type(() => Number) @IsInt() @Min(1)
+  limit?: number;
+
+  @IsOptional() @IsString()
+  cursor?: string;
+}
+
+export interface ResourceResponse {
+  id: string;
+  name: string;
+  email: string | null;
+  kind: ResourceKind;
+  status: ResourceStatus;
+  userId: string | null;
+  avatarUrl: string | null;
+  discipline: string | null;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/packages/shared/src/dto/user.dto.ts
+++ b/packages/shared/src/dto/user.dto.ts
@@ -1,5 +1,11 @@
 import { Type } from 'class-transformer';
-import { IsInt, IsOptional, IsString, Min, MinLength } from 'class-validator';
+import { IsIn, IsInt, IsOptional, IsString, Min, MinLength } from 'class-validator';
+
+export const GLOBAL_ROLES = ['admin', 'pm', 'member'] as const;
+export type GlobalRole = (typeof GLOBAL_ROLES)[number];
+
+export const USER_STATUSES = ['active', 'disabled'] as const;
+export type UserStatus = (typeof USER_STATUSES)[number];
 
 export class SearchUsersQueryDto {
   @IsOptional() @IsString() @MinLength(1)
@@ -17,11 +23,20 @@ export interface UserResponse {
   id: string;
   email: string;
   displayName: string;
-  role: 'admin' | 'pm' | 'member';
+  role: GlobalRole;
+  status: UserStatus;
   avatarUrl: string | null;
 }
 
 export interface PagedResponse<T> {
   items: T[];
   nextCursor: string | null;
+}
+
+export class UpdateUserAdminDto {
+  @IsOptional() @IsIn(GLOBAL_ROLES)
+  role?: GlobalRole;
+
+  @IsOptional() @IsIn(USER_STATUSES)
+  status?: UserStatus;
 }

--- a/packages/shared/src/dto/user.dto.ts
+++ b/packages/shared/src/dto/user.dto.ts
@@ -1,5 +1,13 @@
 import { Type } from 'class-transformer';
-import { IsIn, IsInt, IsOptional, IsString, Min, MinLength } from 'class-validator';
+import {
+  IsEmail,
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  Min,
+  MinLength,
+} from 'class-validator';
 
 export const GLOBAL_ROLES = ['admin', 'pm', 'member'] as const;
 export type GlobalRole = (typeof GLOBAL_ROLES)[number];
@@ -39,4 +47,18 @@ export class UpdateUserAdminDto {
 
   @IsOptional() @IsIn(USER_STATUSES)
   status?: UserStatus;
+}
+
+export class CreateUserAdminDto {
+  @IsEmail()
+  email!: string;
+
+  @IsString() @MinLength(6)
+  password!: string;
+
+  @IsString() @MinLength(1)
+  displayName!: string;
+
+  @IsOptional() @IsIn(GLOBAL_ROLES)
+  role?: GlobalRole;
 }

--- a/packages/shared/src/dto/workload.dto.ts
+++ b/packages/shared/src/dto/workload.dto.ts
@@ -2,7 +2,7 @@ import { IsDateString, IsNumberString, IsOptional, IsString } from 'class-valida
 
 export class CreateWorkloadDto {
   @IsString()
-  userId!: string;
+  resourceId!: string;
 
   @IsString()
   taskId!: string;
@@ -19,7 +19,7 @@ export class CreateWorkloadDto {
 
 export class WorkloadQueryDto {
   @IsOptional() @IsString()
-  userId?: string;
+  resourceId?: string;
 
   @IsOptional() @IsDateString()
   dateFrom?: string;
@@ -30,7 +30,7 @@ export class WorkloadQueryDto {
 
 export interface WorkloadResponse {
   id: string;
-  userId: string;
+  resourceId: string;
   taskId: string;
   projectId: string;
   date: string;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,7 @@
 export * from './dto/user.dto';
 export * from './dto/project.dto';
 export * from './dto/project-member.dto';
+export * from './dto/resource.dto';
 export * from './dto/task.dto';
 export * from './dto/task-link.dto';
 export * from './dto/workload.dto';


### PR DESCRIPTION
## Tipo de Cambio

- [ ] **Patch** (v+0.0.1) - Fix/mejora menor
- [ ] **Minor** (v+0.1.0) - Feature mediana
- [x] **Major** (v+1.0.0) - Epic/Breaking change

## Nueva Versión

**v2.1.0** → **v3.0.0**

## Descripción

### ¿Qué problema resuelve este PR?

La asignación de tareas y workload estaba acoplada 1:1 a `users`: solo se podía
asignar trabajo a una cuenta de usuario existente, sin soportar recursos
provisionales (personas contratadas pero sin acceso al sistema, roles genéricos
tipo "Backend Dev") ni una gestión centralizada de personas. Tampoco existía un
panel de administración para crear usuarios o editar su rol/estado — la única vía
era el seed o acceso directo a la base de datos. Además, `MemberService`
calculaba permisos de gestión de miembros con valores hardcodeados
(`canChangeRoles: false` siempre) y mostraba las mismas etiquetas de rol para rol
global y rol de proyecto, produciendo información incorrecta en la UI.

### ¿Cómo lo resuelve?

- Introduce la entidad `resources` (`kind: 'user' | 'placeholder'`), desacoplada
  de `users`, como el sujeto real de asignación de `tasks.assigneeId` y
  `workload`. Cada usuario real mantiene invariante 1:1 un resource `kind='user'`
  (creado/sincronizado en `auth.sync`); los placeholders se crean y gestionan
  aparte y pueden vincularse después a un usuario real (`link-user`), momento en
  el que sus tasks/workload se reasignan automáticamente.
- Añade endpoints admin para gestión de personas: crear usuarios (Firebase + DB
  transaccional, con compensación si la DB falla tras crear en Firebase), editar
  `role`/`status` de un usuario (con invariante anti-lockout de admins), y editar
  el rol de un miembro de proyecto.
- Añade `UserStatus` (`active`/`disabled`); los usuarios `disabled` quedan
  bloqueados en los tres paths de autenticación del `AuthGuard`.
- Añade el panel `/admin/users` y `/admin/resources`, protegido por rol global
  `admin`.
- Migra el Gantt, la lista de tareas y el servidor MCP para asignar por
  `resource` en lugar de `user`/`member`.
- Corrige `MemberService`/`useMembers` para calcular roles y permisos reales de
  proyecto en vez de valores hardcodeados.

## Cambios Principales

- Módulo `resources`: CRUD admin-only, lectura abierta a cualquier autenticado,
  `link-user` transaccional con reasignación de tasks/workload, `remove`
  restringido a placeholders sin referencias
- `POST /v1/users` y `PATCH /v1/users/:id` (admin): creación con compensación
  Firebase↔DB, edición de role/status con invariante anti-lockout
- `PATCH /v1/projects/:projectId/members/:userId`: edición de rol de proyecto
  (manager-only)
- Bloqueo de usuarios `disabled` en los tres paths del `AuthGuard`
- Panel de administración `/admin/users` y `/admin/resources`
- Columna de avatar de responsable en el Gantt vía inyección DOM
- MCP: `assign_task` busca `resources` en lugar de `users`
- `MemberService`/`useMembers`: roles y permisos de proyecto reales
- 4 migraciones Prisma con backfill (repoint de `tasks.assignee_id` y `workload`
  de `users` a `resources`)

## Archivos Modificados

### Backend (`apps/api`)

- `apps/api/src/resources/` — nuevo módulo: `resources.controller.ts`,
  `resources.service.ts`, `resources.module.ts`, `resources.service.spec.ts`
- `apps/api/src/users/{users.controller,users.service,users.module}.ts` —
  `adminCreate`, `adminUpdate`
- `apps/api/src/firebase/firebase.service.ts` — nuevo: `createUser`/`deleteUser`
  para el flujo de creación admin
- `apps/api/src/auth/{auth.guard,auth.service}.ts` — bloqueo de usuarios
  `disabled`; `sync` en transacción con upsert de `resource`
- `apps/api/src/project-members/{project-members.controller,project-members.service}.ts`
  — `updateRole`, join de `user` en list/create
- `apps/api/src/tasks/tasks.service.ts` — `resolveAssigneeId` → `resolveResourceId`
- `apps/api/src/workload/workload.service.ts`,
  `apps/api/src/calendar/task-rescheduler.service.ts` — `userId` → `resourceId`
- `apps/api/src/app.module.ts` — registro de `ResourcesModule`
- `apps/api/prisma/schema.prisma`, `apps/api/prisma/seed.ts` — modelo `resources`,
  `UserStatus`
- `apps/api/prisma/migrations/20260703203525_add_resources_and_user_status/`,
  `.../20260703203526_backfill_resources_from_users/`,
  `.../20260703203630_repoint_task_assignee_to_resources/`,
  `.../20260703203730_repoint_workload_to_resources/`
- `apps/api/test/resources.e2e-spec.ts` (nuevo), `apps/api/test/workload.e2e-spec.ts`
- `apps/api/openapi.json` — regenerada

### Frontend (`apps/web`)

- `apps/web/src/components/AdminRoute.tsx` — nuevo: gate por rol global `admin`
- `apps/web/src/pages/{AdminUsers,AdminResources}.tsx` — nuevo: paneles de
  gestión de usuarios y recursos
- `apps/web/src/components/ResourceModal.tsx` — nuevo: alta/edición de resource
- `apps/web/src/hooks/useResources.ts`, `apps/web/src/services/resourceService.ts`
  — nuevo: CRUD de `/v1/resources`
- `apps/web/src/utils/ganttAssigneeCells.ts` — nuevo: inyección DOM del avatar de
  responsable en el Gantt
- `apps/web/src/components/GanttChart.tsx`, `apps/web/src/services/ganttDataProvider.ts`
  — integración de `assigneeId` como diff estructural y montaje del observer
- `apps/web/src/pages/ProjectView.tsx` — `useResources` reemplaza a `useMembers`
  para las opciones de responsable
- `apps/web/src/components/{MemberManagement,MemberModal}.tsx`,
  `apps/web/src/hooks/useMembers.ts` — roles/permisos reales de proyecto
- `apps/web/src/components/TaskSidebar/TaskSidebar.tsx`,
  `apps/web/src/components/TasksView/{TaskListView,TasksView,NewTaskRow}.tsx` —
  propagación de `assignees`/`AssigneeOption`
- `apps/web/src/components/ProjectList.tsx`, `apps/web/src/pages/SettingsPage.tsx`
  — `isOwner`, accesos al panel admin
- `apps/web/src/services/userService.ts` — `adminListUsers`, `adminCreateUser`,
  `adminUpdateUser`
- `apps/web/src/App.tsx` — rutas `/admin/users`, `/admin/resources`
- `apps/web/src/types/domain.ts` — `ProjectMember.role: ProjectRole`

### Shared (`packages/shared`)

- `packages/shared/src/dto/resource.dto.ts` — nuevo
- `packages/shared/src/dto/user.dto.ts` — `GlobalRole`, `UserStatus`,
  `UpdateUserAdminDto`, `CreateUserAdminDto`
- `packages/shared/src/dto/project-member.dto.ts` — `UpdateProjectMemberDto`,
  `ProjectMemberResponse.user`
- `packages/shared/src/dto/workload.dto.ts` — `userId` → `resourceId`
- `packages/shared/src/index.ts` — re-exports

### MCP (`packages/mcp`)

- `packages/mcp/src/tools/write-tools.ts` — `assign_task` usa `searchResources`
- `packages/mcp/src/apiClient.ts` — `searchResources` (filtra `status=active`)

### Raíz

- `package.json`, `apps/web/package.json`, `apps/api/package.json`,
  `packages/shared/package.json` — bump `3.0.0` (`packages/mcp` mantiene su
  versionado propio `0.1.0`)
- `CHANGELOG.md` — entrada `3.0.0`

## Checklist Obligatorio

- [x] Código probado localmente
- [x] Versión actualizada en `package.json`
- [x] `CHANGELOG.md` actualizado
- [x] Sin errores de lint (`pnpm run lint`)
- [x] Build exitoso sin errores (`pnpm run build`)
- [x] Tests ejecutados y pasando (`pnpm run test`)

## Checklist Adicional

- [x] Tests unitarios agregados/actualizados
- [ ] Documentación actualizada en `README.md`
- [x] Tipos de TypeScript actualizados
- [x] Migración Prisma generada y commiteada (4 migraciones)
- [x] OpenAPI spec regenerada

## Testing

### Pasos para probar

1. `pnpm run db:up` — levantar PostgreSQL local
2. `pnpm run migrate` — aplicar las 4 migraciones nuevas
3. `pnpm run seed` — sembrar datos (incluye backfill de resources para usuarios existentes)
4. `pnpm run dev` — frontend en 5173, API en 3000
5. Como admin: entrar a `/admin/resources`, crear un placeholder, asignarlo a una
   tarea desde el Gantt o la lista de tareas
6. Crear un usuario nuevo desde `/admin/users`, vincular el placeholder anterior a
   ese usuario desde `/admin/resources` (`link-user`) y verificar que la tarea
   queda reasignada al resource vinculado
7. Cambiar el `status` de un usuario a `disabled` y verificar que no puede
   autenticarse (Firebase ID token, API key)
8. Intentar dejar el sistema sin admins activos (editar el único admin a
   `member`/`disabled`) y verificar el rechazo 400
9. `pnpm run test` — todos los suites deben pasar
10. `pnpm run api:openapi:check` — spec en sync

### Casos de prueba cubiertos

- [x] Flujo normal: crear placeholder, asignarlo, vincularlo a un usuario real,
  verificar reasignación de tasks/workload
- [x] `remove` de resources: 400 sobre `kind='user'`, 409 con tasks/workload
  asociados, 204 en placeholder sin referencias
- [x] `link-user`: 400 si el target no es placeholder, 404 si el usuario no
  existe, borrado del resource huérfano tras el merge
- [x] Gating admin-only en `POST`/`PATCH`/`DELETE` de resources y users; lectura
  abierta a cualquier autenticado
- [x] Invariante anti-lockout de admins en `PATCH /v1/users/:id`
- [x] Compensación Firebase→DB en `adminCreate` ante fallo de transacción
- [x] Bloqueo de usuarios `disabled` en los tres paths del `AuthGuard`

## Impacto

### Breaking Changes

- [x] Sí, introduce breaking changes (describe abajo)

`WorkloadResponse`, `CreateWorkloadDto` y `WorkloadQueryDto` renombran `userId` a
`resourceId`. `tasks.assigneeId` (mismo nombre de campo) ahora referencia
`resources.id` en lugar de `users.id` — cualquier cliente REST o MCP que
consumiera esos campos como IDs de usuario debe migrar a IDs de resource
(`GET /v1/resources` para resolverlos). Las 4 migraciones incluyen backfill
automático: cada usuario existente recibe su resource `kind='user'` y las
referencias de `tasks`/`workload` se remapean sin intervención manual. El bump
Major también sigue la regla de `CONTRIBUTING.md` para épicas completas
(múltiples features relacionadas), consistente con el criterio aplicado en
v2.0.0.

### Rendimiento

- [x] No aplica cambios de rendimiento relevantes

### Seguridad

- [x] Mejora la seguridad

Usuarios `disabled` quedan bloqueados en los tres paths de resolución de
identidad del `AuthGuard` (Firebase ID token, JWT OAuth interno, API key),
incluyendo el path de API key donde además se evita refrescar `lastUsedAt`.

## Dependencias

Requiere aplicar las 4 migraciones Prisma nuevas antes de desplegar. No agrega
variables de entorno nuevas.

## Notas para Revisores

### Áreas que requieren atención especial

- `apps/api/src/resources/resources.service.ts` (`linkToUser`) — corre en
  `$transaction`; reasigna `task.assigneeId` y `workload.resourceId` del
  resource-usuario auto-generado al placeholder destino antes de borrar el
  resource huérfano. No colisiona con el índice único de `workload` porque las
  filas de ambos resources son disjuntas (una tarea tiene un único assignee).
- `apps/api/prisma/migrations/.../repoint_workload_to_resources/migration.sql` —
  es destructiva: elimina (con `RAISE WARNING` previo) filas de `workload` sin
  resource enlazado. No debería ejecutarse en la práctica gracias al backfill
  previo; es una red de seguridad.
- `apps/api/src/users/users.service.ts` (`adminCreate`) — si la transacción DB
  falla después de crear el usuario en Firebase, se compensa con
  `firebase.deleteUser`, y ese borrado traga sus propios errores
  (`.catch(() => undefined)`) para no enmascarar el error original de la
  transacción.
- `apps/web/src/utils/ganttAssigneeCells.ts` — la inyección por DOM
  (`MutationObserver` + `document.createElement`/`textContent`, sin `innerHTML`)
  es un workaround deliberado: `wx-react-gantt` escapa como texto cualquier HTML
  devuelto por `template`, no hay slot de renderizado React/HTML para celdas. No
  revertir a `innerHTML`.

### Decisiones de diseño importantes

- `resources.remove` solo opera sobre `kind='placeholder'`; los resources
  `kind='user'` se gestionan por vínculo/desvínculo, nunca por borrado directo
  (mantiene la invariante 1:1 con `users`).
- `POST /v1/resources` no acepta `kind` en el body aunque el modelo lo soporta —
  se fuerza `placeholder` server-side; `kind='user'` solo se crea vía
  `auth.sync`/`adminCreate`.
- `packages/mcp` no bumpea versión en este PR — mantiene su versionado propio
  `0.x`, igual que en v2.0.0.

## Post-Merge Checklist

- [ ] Aplicar las 4 migraciones Prisma en el entorno destino
- [ ] Confirmar que no quedan clientes externos (API keys) dependiendo del campo
  `workload.userId`
- [ ] Verificar en producción que el backfill de resources cubrió a todos los
  usuarios existentes antes de exponer el panel admin
