### PR TITLE
feat(v3.1.0): Gate project actions by real owner and add detail-view management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ y este proyecto adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-07-13
+
+Acceso a proyectos y gating de acciones por rol real: el gating de acciones de
+tarjeta de proyecto comparaba el uid de Firebase contra el id numérico del
+backend (nunca coincidía), y el conteo de miembros mostrado no reflejaba la
+membresía real. No introduce breaking changes.
+
+### Added
+- `useUserRole` expone `userId`, el id numérico del backend (distinto del
+  `uid` de Firebase)
+- Navegación al detalle de un proyecto por click en toda la tarjeta o en su
+  nombre (antes solo vía el ícono "ver proyecto")
+- Botones "gestionar miembros" y "editar proyecto" en el header de detalle del
+  proyecto (`ProjectView`), gateados por `isAdmin || isOwner`
+- `memberCount` en `GET /v1/projects` y `GET /v1/projects/:id`: total real de
+  personas con acceso (owner + `project_members`)
+
+### Changed
+- Acciones de tarjeta de proyecto (editar, eliminar, gestionar miembros)
+  gateadas por `isAdmin || isOwner` usando el `userId` real, en lugar de la
+  heurística de rol de proyecto (`isPM && isMember`)
+- Tarjeta y header de proyecto muestran `memberCount` en lugar de
+  `project.members.length`
+
+### Fixed
+- El gating de acciones de proyecto comparaba `user.uid` (Firebase) contra
+  `project.ownerId` (id numérico del backend), una comparación que nunca
+  coincidía para el owner real
+- El conteo de miembros mostrado en la tarjeta y en el header del proyecto no
+  reflejaba la membresía real
+
 ## [3.0.0] - 2026-07-08
 
 Epic recursos asignables + panel admin: nueva entidad `resources` (kind

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-workgroup/api",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "description": "Project-Workgroup backend API",
   "scripts": {

--- a/apps/api/src/projects/projects.service.ts
+++ b/apps/api/src/projects/projects.service.ts
@@ -19,18 +19,21 @@ import { toPrisma, toWire } from './status.mapper';
 export class ProjectsService {
   constructor(private readonly prisma: PrismaService) {}
 
-  private toResponse(p: {
-    id: bigint;
-    name: string;
-    description: string | null;
-    startDate: Date;
-    endDate: Date;
-    status: string;
-    ownerId: bigint;
-    color: string;
-    createdAt: Date;
-    updatedAt: Date;
-  }): ProjectResponse {
+  private toResponse(
+    p: {
+      id: bigint;
+      name: string;
+      description: string | null;
+      startDate: Date;
+      endDate: Date;
+      status: string;
+      ownerId: bigint;
+      color: string;
+      createdAt: Date;
+      updatedAt: Date;
+    },
+    memberCount?: number,
+  ): ProjectResponse {
     return {
       id: p.id.toString(),
       name: p.name,
@@ -42,6 +45,7 @@ export class ProjectsService {
       color: p.color,
       createdAt: p.createdAt.toISOString(),
       updatedAt: p.updatedAt.toISOString(),
+      ...(memberCount !== undefined && { memberCount }),
     };
   }
 
@@ -69,14 +73,19 @@ export class ProjectsService {
         OR: [{ ownerId: userId }, { members: { some: { userId } } }],
       },
       orderBy: { createdAt: 'desc' },
+      include: { _count: { select: { members: true } } },
     });
-    return projects.map((p) => this.toResponse(p));
+    // El owner no está en project_members; se suma aparte para el total con acceso.
+    return projects.map((p) => this.toResponse(p, p._count.members + 1));
   }
 
   async getById(id: bigint): Promise<ProjectResponse> {
-    const project = await this.prisma.project.findUnique({ where: { id } });
+    const project = await this.prisma.project.findUnique({
+      where: { id },
+      include: { _count: { select: { members: true } } },
+    });
     if (!project) throw new NotFoundException('project not found');
-    return this.toResponse(project);
+    return this.toResponse(project, project._count.members + 1);
   }
 
   async update(id: bigint, dto: UpdateProjectDto): Promise<ProjectResponse> {

--- a/apps/api/test/projects.e2e-spec.ts
+++ b/apps/api/test/projects.e2e-spec.ts
@@ -104,6 +104,7 @@ describe('Projects (e2e)', () => {
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body.length).toBeGreaterThan(0);
     expect(res.body[0].name).toBe('Test Project');
+    expect(res.body[0].memberCount).toBe(1); // solo el owner, sin project_members
   });
 
   describe('projectRole enforcement on update/delete', () => {
@@ -135,6 +136,14 @@ describe('Projects (e2e)', () => {
           projectRole: 'manager',
         },
       });
+    });
+
+    it('GET /v1/projects/:id → memberCount cuenta owner + members', async () => {
+      const res = await request(handle.app.getHttpServer())
+        .get(`/v1/projects/${scopedProjectId}`)
+        .set('Authorization', 'Bearer fake-token');
+      expect(res.status).toBe(200);
+      expect(res.body.memberCount).toBe(3); // owner + viewer + manager
     });
 
     it('PATCH as viewer → 403', async () => {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@project-workgroup/web",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.1.0",
   "type": "module",
   "engines": {
     "node": ">=20.0.0"

--- a/apps/web/src/__tests__/components/ProjectList.test.tsx
+++ b/apps/web/src/__tests__/components/ProjectList.test.tsx
@@ -259,13 +259,32 @@ describe('ProjectList Component', () => {
         isPM: false,
         isMember: true
       })
-      
+
       renderProjectList()
-      
+
       const viewButtons = screen.getAllByLabelText('Ver proyecto')
       expect(viewButtons.length).toBeGreaterThan(0)
-      
+
+      expect(screen.queryByLabelText('Editar proyecto')).not.toBeInTheDocument()
+      expect(screen.queryByLabelText('Gestionar miembros')).not.toBeInTheDocument()
       expect(screen.queryByLabelText('Eliminar proyecto')).not.toBeInTheDocument()
+    })
+
+    it('debe mostrar botones de acción al owner del proyecto', () => {
+      mockUseUserRole.mockReturnValue({
+        ...defaultUseUserRoleReturn,
+        userRole: 'member',
+        userId: 'user-1', // ownerId de "Proyecto Test 1"
+        isAdmin: false,
+        isMember: true
+      })
+
+      renderProjectList()
+
+      // Solo la tarjeta cuyo ownerId coincide con el usuario expone las acciones.
+      expect(screen.getAllByLabelText('Editar proyecto')).toHaveLength(1)
+      expect(screen.getAllByLabelText('Eliminar proyecto')).toHaveLength(1)
+      expect(screen.getAllByLabelText('Gestionar miembros')).toHaveLength(1)
     })
   })
 

--- a/apps/web/src/__tests__/components/ProjectList.test.tsx
+++ b/apps/web/src/__tests__/components/ProjectList.test.tsx
@@ -62,6 +62,7 @@ const defaultUseProjectsReturn = {
 
 const defaultUseUserRoleReturn = {
   userRole: 'member' as const,
+  userId: null,
   loading: false,
   error: null,
   isAdmin: false,

--- a/apps/web/src/__tests__/components/ProjectList.test.tsx
+++ b/apps/web/src/__tests__/components/ProjectList.test.tsx
@@ -223,10 +223,20 @@ describe('ProjectList Component', () => {
         ...defaultUseProjectsReturn,
         hasMore: false
       })
-      
+
       renderProjectList({ hasMore: false })
-      
+
       expect(screen.queryByText('Cargar Más Proyectos')).not.toBeInTheDocument()
+    })
+
+    it('debe navegar al proyecto al hacer click en su nombre', async () => {
+      const onViewProject = vi.fn()
+      const user = userEvent.setup()
+      renderProjectList({ onViewProject })
+
+      await user.click(screen.getByRole('button', { name: 'Proyecto Test 1' }))
+
+      expect(onViewProject).toHaveBeenCalledWith('project-1')
     })
   })
 
@@ -241,12 +251,10 @@ describe('ProjectList Component', () => {
       })
       
       renderProjectList()
-      
-      const viewButtons = screen.getAllByLabelText('Ver proyecto')
+
       const editButtons = screen.getAllByLabelText('Editar proyecto')
       const deleteButtons = screen.getAllByLabelText('Eliminar proyecto')
-      
-      expect(viewButtons.length).toBeGreaterThan(0)
+
       expect(editButtons.length).toBeGreaterThan(0)
       expect(deleteButtons.length).toBeGreaterThan(0)
     })
@@ -261,9 +269,6 @@ describe('ProjectList Component', () => {
       })
 
       renderProjectList()
-
-      const viewButtons = screen.getAllByLabelText('Ver proyecto')
-      expect(viewButtons.length).toBeGreaterThan(0)
 
       expect(screen.queryByLabelText('Editar proyecto')).not.toBeInTheDocument()
       expect(screen.queryByLabelText('Gestionar miembros')).not.toBeInTheDocument()

--- a/apps/web/src/__tests__/hooks/useProjects.test.ts
+++ b/apps/web/src/__tests__/hooks/useProjects.test.ts
@@ -67,13 +67,14 @@ describe('useProjects Hook', () => {
     
     mockUseUserRole.mockReturnValue({
       userRole: 'member',
+      userId: 'test-uid',
       loading: false,
       error: null,
       isAdmin: false,
       isPM: false,
       isMember: true
     })
-    
+
     ProjectService.getUserProjects = vi.fn().mockResolvedValue({
       items: mockProjects,
       hasMore: false,
@@ -109,6 +110,7 @@ describe('useProjects Hook', () => {
     it('debe cargar todos los proyectos para administradores', async () => {
       mockUseUserRole.mockReturnValue({
         userRole: 'admin',
+        userId: 'test-uid',
         loading: false,
         error: null,
         isAdmin: true,
@@ -129,6 +131,7 @@ describe('useProjects Hook', () => {
     it('debe manejar el estado de carga del rol de usuario', async () => {
       mockUseUserRole.mockReturnValue({
         userRole: null,
+        userId: null,
         loading: true,
         error: null,
         isAdmin: false,
@@ -170,6 +173,7 @@ describe('useProjects Hook', () => {
       
       mockUseUserRole.mockReturnValue({
         userRole: 'member',
+        userId: 'test-uid',
         loading: false,
         error: null,
         isAdmin: false,
@@ -210,6 +214,7 @@ describe('useProjects Hook', () => {
       
       mockUseUserRole.mockReturnValue({
         userRole: 'member',
+        userId: 'test-uid',
         loading: false,
         error: null,
         isAdmin: false,

--- a/apps/web/src/components/Layout/ProjectMeta.tsx
+++ b/apps/web/src/components/Layout/ProjectMeta.tsx
@@ -32,7 +32,7 @@ const formatStatus = (status: string) =>
 const ProjectMeta: React.FC<ProjectMetaProps> = ({ project, tasksCount }) => {
   const status = project.status || 'planning';
   const variant = STATUS_VARIANT[status.toLowerCase()] ?? 'outline';
-  const memberCount = project.members?.length ?? 0;
+  const memberCount = project.memberCount ?? 0;
 
   return (
     <div

--- a/apps/web/src/components/ProjectList.tsx
+++ b/apps/web/src/components/ProjectList.tsx
@@ -3,7 +3,6 @@ import type { Project, ProjectStatus } from '../types/domain';
 import { useUserRole } from '../hooks/useUserRole';
 import MemberModal from './MemberModal';
 import {
-  Eye,
   Users,
   Edit3,
   Trash2,
@@ -48,8 +47,6 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, isAdmin, currentUser
   const canEdit = isAdmin || isOwner;
   const canDelete = isAdmin || isOwner;
   const canManageMembers = isAdmin || isOwner;
-  // Todo proyecto presente en la lista ya es visible para el usuario (el backend la filtra).
-  const canView = true;
 
   const variant = STATUS_VARIANT[project.status] ?? 'outline';
 
@@ -59,7 +56,10 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, isAdmin, currentUser
       style={{
         boxShadow: 'var(--sh-1)',
         transition: 'box-shadow var(--dur) var(--ease), border-color var(--dur) var(--ease)',
+        cursor: 'pointer',
       }}
+      // Toda la tarjeta abre el proyecto; los botones de acción detienen la propagación.
+      onClick={() => onView(project.id)}
       onMouseEnter={(e) => {
         e.currentTarget.style.boxShadow = 'var(--sh-2)';
         e.currentTarget.style.borderColor = 'var(--line-2)';
@@ -83,28 +83,45 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, isAdmin, currentUser
                 letterSpacing: 'var(--tr-h3)',
                 color: 'var(--ink)',
                 margin: 0,
+                minWidth: 0,
               }}
             >
-              {project.name}
+              {/* Control enfocable por teclado que abre el proyecto (la tarjeta no es un botón). */}
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onView(project.id);
+                }}
+                className="truncate"
+                title={project.name}
+                style={{
+                  font: 'inherit',
+                  letterSpacing: 'inherit',
+                  color: 'inherit',
+                  background: 'none',
+                  border: 0,
+                  padding: 0,
+                  margin: 0,
+                  maxWidth: '100%',
+                  textAlign: 'left',
+                  cursor: 'pointer',
+                }}
+              >
+                {project.name}
+              </button>
             </h3>
           </div>
           <span className={`badge ${variant} dot`}>{STATUS_LABEL[project.status]}</span>
         </div>
 
         <div className="flex items-center gap-0.5 shrink-0">
-          {canView && (
-            <button
-              onClick={() => onView(project.id)}
-              className="btn btn-ghost btn-icon btn-sm"
-              title="Ver proyecto"
-              aria-label="Ver proyecto"
-            >
-              <Eye className="w-4 h-4" />
-            </button>
-          )}
           {canManageMembers && (
             <button
-              onClick={() => onManageMembers(project)}
+              onClick={(e) => {
+                e.stopPropagation();
+                onManageMembers(project);
+              }}
               className="btn btn-ghost btn-icon btn-sm"
               title="Gestionar miembros"
               aria-label="Gestionar miembros"
@@ -114,7 +131,10 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, isAdmin, currentUser
           )}
           {canEdit && (
             <button
-              onClick={() => onEdit(project)}
+              onClick={(e) => {
+                e.stopPropagation();
+                onEdit(project);
+              }}
               className="btn btn-ghost btn-icon btn-sm"
               title="Editar proyecto"
               aria-label="Editar proyecto"
@@ -124,7 +144,10 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, isAdmin, currentUser
           )}
           {canDelete && (
             <button
-              onClick={() => onDelete(project.id)}
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(project.id);
+              }}
               className="btn btn-ghost btn-icon btn-sm"
               title="Eliminar proyecto"
               aria-label="Eliminar proyecto"

--- a/apps/web/src/components/ProjectList.tsx
+++ b/apps/web/src/components/ProjectList.tsx
@@ -192,7 +192,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, isAdmin, currentUser
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-1.5" style={{ font: '400 var(--t-small)/1 var(--font-sans)', color: 'var(--ink-2)' }}>
             <Users className="w-3.5 h-3.5" style={{ color: 'var(--ink-3)' }} />
-            <span>{project.members.length} miembro{project.members.length !== 1 ? 's' : ''}</span>
+            <span>{project.memberCount ?? 0} miembro{(project.memberCount ?? 0) !== 1 ? 's' : ''}</span>
           </div>
           <div className="flex items-center gap-1" style={{ font: '400 var(--t-caption)/1 var(--font-mono)', color: 'var(--ink-4)' }}>
             <Clock className="w-3 h-3" />

--- a/apps/web/src/components/ProjectList.tsx
+++ b/apps/web/src/components/ProjectList.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import type { Project, ProjectStatus } from '../types/domain';
-import { useAuth } from '../contexts/AuthContext';
 import { useUserRole } from '../hooks/useUserRole';
 import MemberModal from './MemberModal';
 import {
@@ -17,6 +16,8 @@ import {
 
 interface ProjectCardProps {
   project: Project;
+  isAdmin: boolean;
+  currentUserId: string | null;
   onEdit: (project: Project) => void;
   onDelete: (projectId: string) => void;
   onView: (projectId: string) => void;
@@ -40,16 +41,15 @@ const STATUS_LABEL: Record<ProjectStatus, string> = {
 const formatDate = (date: string) =>
   new Intl.DateTimeFormat('es-ES', { year: 'numeric', month: 'short', day: 'numeric' }).format(new Date(date));
 
-const ProjectCard: React.FC<ProjectCardProps> = ({ project, onEdit, onDelete, onView, onManageMembers }) => {
-  const { user } = useAuth();
-  const { isAdmin, isPM } = useUserRole();
-  const isOwner = user?.uid === project.ownerId;
-  const isMember = project.members.includes(user?.uid || '');
+const ProjectCard: React.FC<ProjectCardProps> = ({ project, isAdmin, currentUserId, onEdit, onDelete, onView, onManageMembers }) => {
+  // ownerId es el id numérico del backend; comparamos contra el id del usuario, no el uid de Firebase.
+  const isOwner = currentUserId != null && currentUserId === project.ownerId;
 
-  const canEdit = isAdmin || isOwner || (isPM && isMember);
+  const canEdit = isAdmin || isOwner;
   const canDelete = isAdmin || isOwner;
-  const canView = isAdmin || isOwner || isMember;
-  const canManageMembers = isAdmin || isPM;
+  const canManageMembers = isAdmin || isOwner;
+  // Todo proyecto presente en la lista ya es visible para el usuario (el backend la filtra).
+  const canView = true;
 
   const variant = STATUS_VARIANT[project.status] ?? 'outline';
 
@@ -204,8 +204,7 @@ const ProjectList: React.FC<ProjectListProps> = ({
   onDeleteProject,
   onLoadMore,
 }) => {
-  const { user } = useAuth();
-  const { isAdmin, isPM } = useUserRole();
+  const { isAdmin, isPM, userId } = useUserRole();
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [memberModalOpen, setMemberModalOpen] = useState(false);
   const [selectedProject, setSelectedProject] = useState<Project | null>(null);
@@ -358,6 +357,8 @@ const ProjectList: React.FC<ProjectListProps> = ({
               >
                 <ProjectCard
                   project={project}
+                  isAdmin={isAdmin}
+                  currentUserId={userId}
                   onEdit={onEditProject}
                   onDelete={handleDelete}
                   onView={onViewProject}
@@ -383,7 +384,7 @@ const ProjectList: React.FC<ProjectListProps> = ({
           onClose={closeMemberModal}
           projectId={selectedProject.id}
           projectName={selectedProject.name}
-          isOwner={user?.uid === selectedProject.ownerId}
+          isOwner={!!userId && userId === selectedProject.ownerId}
         />
       )}
     </div>

--- a/apps/web/src/hooks/useUserRole.ts
+++ b/apps/web/src/hooks/useUserRole.ts
@@ -8,6 +8,8 @@ import { useAuth } from '../contexts/AuthContext';
 export function useUserRole() {
   const { user } = useAuth();
   const [userRole, setUserRole] = useState<string | null>(null);
+  // Id numérico del backend (distinto del uid de Firebase); habilita comparar contra ownerId.
+  const [userId, setUserId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -15,6 +17,7 @@ export function useUserRole() {
     const fetchUserRole = async () => {
       if (!user) {
         setUserRole(null);
+        setUserId(null);
         setLoading(false);
         return;
       }
@@ -24,10 +27,12 @@ export function useUserRole() {
         setError(null);
         const userData = await UserService.getUser(user.uid);
         setUserRole(userData?.role || 'member');
+        setUserId(userData?.id ?? null);
       } catch (err) {
         console.error('Error fetching user role:', err);
         setError('Error al obtener el rol del usuario');
         setUserRole('member'); // Rol por defecto
+        setUserId(null);
       } finally {
         setLoading(false);
       }
@@ -38,6 +43,7 @@ export function useUserRole() {
 
   return {
     userRole,
+    userId,
     loading,
     error,
     isAdmin: userRole === 'admin',

--- a/apps/web/src/pages/ProjectView.tsx
+++ b/apps/web/src/pages/ProjectView.tsx
@@ -4,11 +4,16 @@ import { useQueryClient } from '@tanstack/react-query';
 import 'wx-react-gantt/dist/gantt.css';
 import '../styles/gantt-custom.css';
 import { useTasks } from '../hooks/usetasks';
+import { Users, Edit3 } from 'lucide-react';
 import { useProject } from '../hooks/useProject';
 import { useResources } from '../hooks/useResources';
 import { useAuth } from '../contexts/AuthContext';
+import { useUserRole } from '../hooks/useUserRole';
 import { useNavigation } from '../contexts/NavigationContext';
 import { ProjectActions, ProjectMeta } from '../components/Layout';
+import MemberModal from '../components/MemberModal';
+import ProjectModal from '../components/ProjectModal';
+import { ProjectService } from '../services/projectService';
 import TasksView from '../components/TasksView/TasksView';
 import type { NewTaskInput } from '../components/TasksView/NewTaskRow';
 import { ProjectStateManager } from '../components/ProjectLoadingStates';
@@ -22,7 +27,7 @@ import { ProjectSettingsProvider } from '../contexts/ProjectSettingsContext';
 import { applySummaryPatches } from '../lib/summaryPatches';
 import { calendarService } from '../services/calendarService';
 import type { WorkingCalendarResponse } from '@project-workgroup/shared';
-import type { Task, TaskLink, TaskPriority, TaskStatus, TaskType } from '../types/domain';
+import type { CreateProjectData, Task, TaskLink, TaskPriority, TaskStatus, TaskType, UpdateProjectData } from '../types/domain';
 import type { GanttApi } from 'wx-react-gantt';
 
 // Referencia estable para no reiniciar useResources en cada render.
@@ -33,10 +38,16 @@ const ProjectView: React.FC = () => {
   const navigate = useNavigate();
   const ganttApiRef = useRef<GanttApi | null>(null);
   const { user } = useAuth();
+  const { isAdmin, userId } = useUserRole();
   const { updateNavigation } = useNavigation();
   const queryClient = useQueryClient();
 
   const { project, loading, error, refetch } = useProject(projectId);
+  const [memberModalOpen, setMemberModalOpen] = React.useState(false);
+  const [editModalOpen, setEditModalOpen] = React.useState(false);
+
+  // Solo admin u owner gestionan el proyecto (alineado con lo que autoriza el backend).
+  const canManage = isAdmin || (!!userId && userId === project?.ownerId);
   const { tasks, loading: tasksLoading, error: tasksError, refetch: refetchTasks } = useTasks(projectId);
   const { data: taskLinks = [] } = useProjectTaskLinksQuery(user ? projectId : undefined);
   const { data: projectSettings } = useProjectSettingsQuery(user ? projectId : undefined);
@@ -109,6 +120,16 @@ const ProjectView: React.FC = () => {
     if (projectId) navigate(`/project/${projectId}/settings`);
   }, [projectId, navigate]);
 
+  const handleEditSubmit = React.useCallback(
+    async (data: CreateProjectData | UpdateProjectData) => {
+      if (!project) return;
+      await ProjectService.updateProject(project.id, data as UpdateProjectData);
+      setEditModalOpen(false);
+      await refetch();
+    },
+    [project, refetch],
+  );
+
   const tasksCount = tasks.length;
 
   const projectActions = React.useMemo(() => {
@@ -121,10 +142,32 @@ const ProjectView: React.FC = () => {
           className="hidden md:block"
           style={{ width: 1, height: 18, background: 'var(--line-2)' }}
         />
-        <ProjectActions onOpenCalendar={handleOpenCalendar} calendar={calendar} />
+        <div className="flex items-center gap-1">
+          {canManage && (
+            <>
+              <button
+                onClick={() => setMemberModalOpen(true)}
+                className="btn btn-ghost btn-icon btn-sm"
+                title="Gestionar miembros"
+                aria-label="Gestionar miembros"
+              >
+                <Users className="w-4 h-4" />
+              </button>
+              <button
+                onClick={() => setEditModalOpen(true)}
+                className="btn btn-ghost btn-icon btn-sm"
+                title="Editar proyecto"
+                aria-label="Editar proyecto"
+              >
+                <Edit3 className="w-4 h-4" />
+              </button>
+            </>
+          )}
+          <ProjectActions onOpenCalendar={handleOpenCalendar} calendar={calendar} />
+        </div>
       </div>
     );
-  }, [project, tasksCount, handleOpenCalendar, calendar]);
+  }, [project, tasksCount, handleOpenCalendar, calendar, canManage]);
 
   const crumbs = React.useMemo(
     () =>
@@ -272,6 +315,25 @@ const ProjectView: React.FC = () => {
             />
           </div>
         </div>
+
+        {project && (
+          <>
+            <MemberModal
+              isOpen={memberModalOpen}
+              onClose={() => setMemberModalOpen(false)}
+              projectId={project.id}
+              projectName={project.name}
+              isOwner={!!userId && userId === project.ownerId}
+            />
+            <ProjectModal
+              isOpen={editModalOpen}
+              onClose={() => setEditModalOpen(false)}
+              onSubmit={handleEditSubmit}
+              project={project}
+              mode="edit"
+            />
+          </>
+        )}
       </ProjectSettingsProvider>
     </ProjectStateManager>
   );

--- a/apps/web/src/services/projectService.ts
+++ b/apps/web/src/services/projectService.ts
@@ -33,6 +33,7 @@ const toDomain = (r: RawProject): Project => ({
   status: r.status,
   ownerId: r.ownerId,
   members: r.members ?? [],
+  memberCount: r.memberCount ?? 0,
   color: r.color ?? '#3B82F6',
   createdAt: r.createdAt ?? '',
   updatedAt: r.updatedAt ?? '',

--- a/apps/web/src/types/domain.ts
+++ b/apps/web/src/types/domain.ts
@@ -46,6 +46,7 @@ export interface Project extends BaseDocument {
   status: ProjectStatus;
   ownerId: string;
   members: string[];
+  memberCount?: number;
   color: string;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "project-workgroup",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.1.0",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-workgroup/shared",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/shared/src/dto/project.dto.ts
+++ b/packages/shared/src/dto/project.dto.ts
@@ -54,6 +54,8 @@ export interface ProjectResponse {
   color: string;
   createdAt: string;
   updatedAt: string;
+  // Total de personas con acceso (owner + filas de project_members). Solo en rutas de lectura.
+  memberCount?: number;
 }
 
 export const TIME_GRANULARITIES = ['hours', 'days'] as const;


### PR DESCRIPTION
## Tipo de Cambio

- [ ] **Patch** (v+0.0.1) - Fix/mejora menor
- [x] **Minor** (v+0.1.0) - Feature mediana
- [ ] **Major** (v+1.0.0) - Epic/Breaking change

## Nueva Versión

**v3.0.0** → **v3.1.0**

## Descripción

### ¿Qué problema resuelve este PR?

Las acciones de tarjeta de proyecto (editar, eliminar, gestionar miembros) se
gateaban comparando `user.uid` (el uid de Firebase) contra `project.ownerId`,
que en realidad almacena el id numérico del backend — una comparación que
nunca coincidía para el owner real. Como consecuencia, el gating efectivo
dependía de una heurística de rol de proyecto (`isPM && isMember`) que no
reflejaba la autorización real que ya aplicaba el backend
(`ProjectMembershipGuard`: owner o admin). Entrar al detalle de un proyecto
solo era posible desde un ícono de "ver" aparte, no desde la tarjeta ni el
nombre. Además, el conteo de miembros mostrado en la tarjeta y en el header
del proyecto usaba `project.members.length`, un array que el frontend nunca
poblaba con la membresía completa, mostrando cifras incorrectas. Por último,
la vista de detalle (`ProjectView`) no exponía ninguna acción de gestión —
había que volver al listado para editar el proyecto o administrar sus
miembros.

### ¿Cómo lo resuelve?

- `useUserRole` expone ahora `userId`, el id numérico del backend obtenido de
  `UserService.getUser`, distinto del `uid` de Firebase.
- `ProjectList`/`ProjectCard` derivan `isOwner` comparando `userId` (no
  `user.uid`) contra `project.ownerId`, y simplifican
  `canEdit`/`canDelete`/`canManageMembers` a `isAdmin || isOwner`, alineado
  con lo que efectivamente autoriza el backend.
- Clic en toda la tarjeta o en el nombre del proyecto navega a su detalle; los
  botones de acción cortan la propagación del evento para no disparar la
  navegación de la tarjeta.
- El backend calcula `memberCount` real (`_count.members + 1` por el owner,
  que no vive en `project_members`) en `getUserProjects`/`getById`, expuesto
  como campo opcional en `ProjectResponse`. El frontend lo propaga
  (`projectService.toDomain`, `Project.memberCount`) y lo consume en
  `ProjectMeta` y en la tarjeta del listado en lugar del array `members`.
- `ProjectView` agrega botones de "gestionar miembros" y "editar proyecto" en
  el header de detalle, gateados por `canManage = isAdmin || isOwner`,
  reutilizando los modales existentes (`MemberModal`, `ProjectModal`) en lugar
  de duplicar UI.

## Cambios Principales

- `useUserRole`: nuevo campo `userId` (id numérico del backend)
- Gating de acciones de proyecto (tarjeta y detalle) por `isAdmin || isOwner`
  real, usando `userId` en lugar de `user.uid`
- Navegación al detalle de proyecto por click en la tarjeta o en el nombre
- Botones "gestionar miembros" y "editar proyecto" en el header de
  `ProjectView`
- `memberCount` real (owner + `project_members`) en `GET /v1/projects` y
  `GET /v1/projects/:id`, propagado a `ProjectMeta` y a la tarjeta del listado

## Archivos Modificados

### Backend (`apps/api`)

- `apps/api/src/projects/projects.service.ts` — `toResponse` acepta
  `memberCount` opcional; `getUserProjects`/`getById` incluyen
  `_count.select.members` y suman +1 por el owner
- `apps/api/test/projects.e2e-spec.ts` — casos para `memberCount` (solo owner,
  owner + members)

### Frontend (`apps/web`)

- `apps/web/src/hooks/useUserRole.ts` — expone `userId`
- `apps/web/src/components/ProjectList.tsx` — `ProjectCard` recibe
  `isAdmin`/`currentUserId` por props, gating por owner real, click en
  tarjeta/nombre abre el proyecto, `memberCount` en vez de `members.length`
- `apps/web/src/components/Layout/ProjectMeta.tsx` — `memberCount` en vez de
  `members?.length`
- `apps/web/src/pages/ProjectView.tsx` — botones de miembros/editar en el
  header, `MemberModal`/`ProjectModal` montados condicionalmente
- `apps/web/src/services/projectService.ts` — mapea `memberCount` en
  `toDomain`
- `apps/web/src/types/domain.ts` — `Project.memberCount?: number`
- `apps/web/src/__tests__/components/ProjectList.test.tsx` — cobertura de
  navegación por click, gating por owner real y ausencia de acciones para
  member/PM no-owner
- `apps/web/src/__tests__/hooks/useProjects.test.ts` — mocks de `useUserRole`
  actualizados con `userId` (ver nota en Checklist Obligatorio)

### Shared (`packages/shared`)

- `packages/shared/src/dto/project.dto.ts` — `ProjectResponse.memberCount?:
  number`

### Raíz

- `package.json`, `apps/web/package.json`, `apps/api/package.json`,
  `packages/shared/package.json` — bump `3.1.0` (`packages/mcp` mantiene su
  versionado propio `0.1.0`)
- `CHANGELOG.md` — entrada `3.1.0`

## Checklist Obligatorio

- [x] Código probado localmente
- [x] Versión actualizada en `package.json`
- [x] `CHANGELOG.md` actualizado
- [x] Sin errores de lint (`pnpm run lint`)
- [x] Build exitoso sin errores (`pnpm run build`)
- [x] Tests ejecutados y pasando (`pnpm run test`) — verificado también con
      Node 20.20.0 (versión exacta de CI)

> **Nota:** `apps/web/src/__tests__/hooks/useProjects.test.ts` tiene el fix de
> mocks aplicado en el working tree pero **sin commitear**. Sin ese commit,
> `pnpm run build` falla en CI con `TS2345` (los mocks de `useUserRole` no
> incluyen la propiedad `userId`, ahora requerida). Debe commitearse antes de
> abrir el PR.

## Checklist Adicional

- [x] Tests unitarios agregados/actualizados
- [ ] Documentación actualizada en `README.md`
- [x] Tipos de TypeScript actualizados
- [ ] Migración Prisma generada (no aplica — `memberCount` es derivado vía
      `_count`, no persiste en columna propia)
- [x] OpenAPI spec regenerada — sin cambios (`ProjectResponse` es una
      interfaz TS, no expone `memberCount` en el schema Swagger; verificado
      con `pnpm run api:openapi:check`)

## Testing

### Pasos para probar

1. `pnpm run dev` — frontend en 5173, API en 3000
2. Loguearse como un usuario owner de al menos un proyecto y, en otra sesión,
   como admin y como member/PM sin proyectos propios
3. En `/dashboard`: verificar que el conteo de miembros de cada tarjeta
   coincide con `project_members` + 1 (el owner)
4. Click en cualquier zona de la tarjeta o en el nombre del proyecto → navega
   a `/project/:id`
5. Como owner o admin: confirmar que aparecen "gestionar miembros" y "editar"
   tanto en la tarjeta del listado como en el header de detalle; como
   member/PM sin ser owner, confirmar que no aparecen
6. Desde el header de `/project/:id`, abrir "gestionar miembros" y "editar
   proyecto" y confirmar que los modales funcionan igual que desde el listado
7. `pnpm run test` — todos los suites deben pasar

### Casos de prueba cubiertos

- [x] `GET /v1/projects` → `memberCount = 1` para un proyecto sin
  `project_members` (solo el owner)
- [x] `GET /v1/projects/:id` → `memberCount` cuenta owner + members
- [x] `ProjectList`: navegación al hacer click en el nombre del proyecto
- [x] `ProjectList`: acciones ausentes para member/PM que no es owner
- [x] `ProjectList`: acciones presentes solo en la tarjeta cuyo `ownerId`
  coincide con el `userId` actual
- [x] `useProjects`: mocks de `useUserRole` cubren loading/error/success con
  `userId`

## Impacto

### Breaking Changes

- [ ] No introduce breaking changes

`memberCount` es un campo opcional agregado a `ProjectResponse`; ningún
consumidor existente depende de su ausencia. El gating de acciones en el
frontend se vuelve más restrictivo (un PM que no es owner deja de ver
acciones de gestión), pero corrige un bug de autorización del cliente: el
backend ya rechazaba esas operaciones para roles sin permiso real.

### Rendimiento

- [x] No aplica cambios de rendimiento relevantes

`_count.select.members` agrega un subquery liviano a las consultas de listado
y detalle de proyectos; sin impacto medible observado en desarrollo.

### Seguridad

- [x] No aplica cambios de seguridad relevantes

El gating de UI ahora refleja la autorización real (`isAdmin || isOwner`); no
cambia la autorización del backend (`ProjectMembershipGuard` sigue siendo la
fuente de verdad), solo deja de mostrar acciones que el backend ya rechazaba.

## Dependencias

No agrega variables de entorno ni requiere pasos de despliegue adicionales.
No hay migraciones Prisma pendientes de aplicar.

## Notas para Revisores

### Áreas que requieren atención especial

- `apps/web/src/components/ProjectList.tsx` — el `onClick` de la tarjeta y los
  `onClick` de cada botón de acción usan `e.stopPropagation()`; cualquier
  acción nueva que se agregue a la tarjeta debe seguir el mismo patrón o
  heredará la navegación de la tarjeta completa.
- `apps/api/src/projects/projects.service.ts` (`toResponse`) — `memberCount`
  es opcional (`...(memberCount !== undefined && { memberCount })`) porque
  `toResponse` también se usa en `create`/`update`, donde no se calcula
  `_count`; evita enviar `memberCount: undefined` explícito en esas
  respuestas.

### Decisiones de diseño importantes

- `canManageMembers` ahora coincide con `canEdit` (`isAdmin || isOwner`) en
  vez de `isAdmin || isPM`: un PM que no sea owner del proyecto ya no puede
  gestionar miembros desde la tarjeta, consistente con
  `project-membership.guard.ts`.
- El botón "ver proyecto" (ícono `Eye`) se elimina de la tarjeta: la tarjeta
  completa y el nombre cumplen esa función; se optó por no duplicar el
  affordance.

## Post-Merge Checklist

- [ ] Verificar en producción que el conteo de miembros mostrado coincide con
  la membresía real tras el deploy
